### PR TITLE
[codex] Add credentials auth foundation

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@prisma/client": "^6.19.3",
+        "bcryptjs": "^3.0.3",
         "next": "16.2.6",
+        "next-auth": "^5.0.0-beta.31",
         "prisma": "^6.19.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -53,6 +55,35 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1726,6 +1757,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@prisma/client": {
@@ -4358,6 +4398,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -6971,6 +7020,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-file-download": {
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
@@ -7649,6 +7707,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7759,6 +7844,15 @@
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -8142,6 +8236,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@prisma/client": "^6.19.3",
+    "bcryptjs": "^3.0.3",
     "next": "16.2.6",
+    "next-auth": "^5.0.0-beta.31",
     "prisma": "^6.19.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -21,13 +21,14 @@ enum ListingStatus {
 }
 
 model User {
-  id        String    @id @default(auto()) @map("_id") @db.ObjectId
-  email     String    @unique
-  name      String?
-  image     String?
-  listings  Listing[]
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
+  id           String    @id @default(auto()) @map("_id") @db.ObjectId
+  email        String    @unique
+  name         String?
+  image        String?
+  passwordHash String?
+  listings     Listing[]
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 }
 
 model Listing {

--- a/apps/web/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/server/auth/auth";
+
+export const { GET, POST } = handlers;

--- a/apps/web/src/app/api/auth/register/route.test.ts
+++ b/apps/web/src/app/api/auth/register/route.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "@/app/api/auth/register/route";
+import { registerUser } from "@/features/auth/users";
+
+vi.mock("@/features/auth/users", () => ({
+  registerUser: vi.fn(),
+}));
+
+describe("POST /api/auth/register", () => {
+  beforeEach(() => {
+    vi.mocked(registerUser).mockReset();
+  });
+
+  it("registers a user with a valid request body", async () => {
+    vi.mocked(registerUser).mockResolvedValue({
+      id: "507f1f77bcf86cd799439011",
+      email: "user@example.com",
+      name: "Kushal",
+      image: null,
+    });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/auth/register", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "USER@example.COM",
+          name: "Kushal",
+          password: "Password1",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        user: {
+          id: "507f1f77bcf86cd799439011",
+          email: "user@example.com",
+          name: "Kushal",
+          image: null,
+        },
+      },
+    });
+    expect(registerUser).toHaveBeenCalledWith({
+      email: "user@example.com",
+      name: "Kushal",
+      password: "Password1",
+    });
+  });
+
+  it("returns validation errors for weak passwords", async () => {
+    const response = await POST(
+      new Request("http://localhost:3000/api/auth/register", {
+        method: "POST",
+        body: JSON.stringify({
+          email: "user@example.com",
+          name: "Kushal",
+          password: "password",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "VALIDATION_ERROR",
+        status: 400,
+      },
+    });
+    expect(registerUser).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -1,0 +1,20 @@
+import { registerBodySchema } from "@/features/auth/schemas";
+import { registerUser } from "@/features/auth/users";
+import { readJsonBody } from "@/server/api/request";
+import { apiData, throwIfInvalid, withApiErrorHandling } from "@/server/api/responses";
+
+export async function POST(request: Request) {
+  return withApiErrorHandling(async () => {
+    const body = throwIfInvalid(
+      registerBodySchema.safeParse(await readJsonBody(request)),
+    );
+    const user = await registerUser(body);
+
+    return apiData(
+      {
+        user,
+      },
+      { status: 201 },
+    );
+  });
+}

--- a/apps/web/src/app/api/listings/[id]/route.test.ts
+++ b/apps/web/src/app/api/listings/[id]/route.test.ts
@@ -7,6 +7,10 @@ vi.mock("@/features/listings/queries", () => ({
   getListingById: vi.fn(),
 }));
 
+vi.mock("@/server/auth/current-user", () => ({
+  requireCurrentUser: vi.fn(),
+}));
+
 const listing = {
   id: "507f1f77bcf86cd799439011",
   title: "Sunny room near SCSU",

--- a/apps/web/src/app/api/listings/[id]/route.ts
+++ b/apps/web/src/app/api/listings/[id]/route.ts
@@ -6,9 +6,9 @@ import {
 import { getListingById } from "@/features/listings/queries";
 import { archiveListing, updateListing } from "@/features/listings/mutations";
 import { listingNotFound } from "@/server/api/errors";
-import { assertLocalWriteApiAllowed } from "@/server/api/local-only";
 import { readJsonBody } from "@/server/api/request";
 import { apiData, throwIfInvalid, withApiErrorHandling } from "@/server/api/responses";
+import { requireCurrentUser } from "@/server/auth/current-user";
 
 export const dynamic = "force-dynamic";
 
@@ -35,7 +35,7 @@ export async function GET(_request: Request, context: ListingRouteContext) {
 
 export async function PATCH(request: Request, context: ListingRouteContext) {
   return withApiErrorHandling(async () => {
-    assertLocalWriteApiAllowed();
+    const currentUser = await requireCurrentUser();
 
     const params = throwIfInvalid(
       listingParamsSchema.safeParse(await context.params),
@@ -43,7 +43,7 @@ export async function PATCH(request: Request, context: ListingRouteContext) {
     const body = throwIfInvalid(
       listingUpdateBodySchema.safeParse(await readJsonBody(request)),
     );
-    const listing = await updateListing(params.id, body);
+    const listing = await updateListing(params.id, body, currentUser.id);
 
     if (!listing) {
       throw listingNotFound(params.id);
@@ -57,12 +57,12 @@ export async function PATCH(request: Request, context: ListingRouteContext) {
 
 export async function DELETE(_request: Request, context: ListingRouteContext) {
   return withApiErrorHandling(async () => {
-    assertLocalWriteApiAllowed();
+    const currentUser = await requireCurrentUser();
 
     const params = throwIfInvalid(
       listingParamsSchema.safeParse(await context.params),
     );
-    const listing = await archiveListing(params.id);
+    const listing = await archiveListing(params.id, currentUser.id);
 
     if (!listing) {
       throw listingNotFound(params.id);

--- a/apps/web/src/app/api/listings/route.test.ts
+++ b/apps/web/src/app/api/listings/route.test.ts
@@ -7,6 +7,10 @@ vi.mock("@/features/listings/queries", () => ({
   getActiveListings: vi.fn(),
 }));
 
+vi.mock("@/server/auth/current-user", () => ({
+  requireCurrentUser: vi.fn(),
+}));
+
 const listing = {
   id: "507f1f77bcf86cd799439011",
   title: "Sunny room near SCSU",

--- a/apps/web/src/app/api/listings/route.ts
+++ b/apps/web/src/app/api/listings/route.ts
@@ -7,9 +7,9 @@ import {
 } from "@/features/listings/schemas";
 import { getActiveListings } from "@/features/listings/queries";
 import { createListing } from "@/features/listings/mutations";
-import { assertLocalWriteApiAllowed } from "@/server/api/local-only";
 import { readJsonBody } from "@/server/api/request";
 import { apiData, throwIfInvalid, withApiErrorHandling } from "@/server/api/responses";
+import { requireCurrentUser } from "@/server/auth/current-user";
 
 export const dynamic = "force-dynamic";
 
@@ -32,12 +32,12 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   return withApiErrorHandling(async () => {
-    assertLocalWriteApiAllowed();
+    const currentUser = await requireCurrentUser();
 
     const body = throwIfInvalid(
       listingCreateBodySchema.safeParse(await readJsonBody(request)),
     );
-    const listing = await createListing(body);
+    const listing = await createListing(body, currentUser.id);
 
     return apiData(
       {

--- a/apps/web/src/app/api/listings/write-routes.test.ts
+++ b/apps/web/src/app/api/listings/write-routes.test.ts
@@ -7,6 +7,8 @@ import {
   createListing,
   updateListing,
 } from "@/features/listings/mutations";
+import { authRequired, forbidden } from "@/server/api/errors";
+import { requireCurrentUser } from "@/server/auth/current-user";
 
 vi.mock("@/features/listings/queries", () => ({
   getActiveListings: vi.fn(),
@@ -17,6 +19,10 @@ vi.mock("@/features/listings/mutations", () => ({
   archiveListing: vi.fn(),
   createListing: vi.fn(),
   updateListing: vi.fn(),
+}));
+
+vi.mock("@/server/auth/current-user", () => ({
+  requireCurrentUser: vi.fn(),
 }));
 
 const listing = {
@@ -46,6 +52,11 @@ describe("local listing write APIs", () => {
     vi.mocked(archiveListing).mockReset();
     vi.mocked(createListing).mockReset();
     vi.mocked(updateListing).mockReset();
+    vi.mocked(requireCurrentUser).mockResolvedValue({
+      id: "507f1f77bcf86cd799439099",
+      email: "owner@example.com",
+      name: "Owner",
+    });
   });
 
   it("creates a listing from a valid request body", async () => {
@@ -87,6 +98,7 @@ describe("local listing write APIs", () => {
         type: listing.type,
         status: "ACTIVE",
       }),
+      "507f1f77bcf86cd799439099",
     );
   });
 
@@ -137,7 +149,11 @@ describe("local listing write APIs", () => {
         },
       },
     });
-    expect(updateListing).toHaveBeenCalledWith(listing.id, { rent: 700 });
+    expect(updateListing).toHaveBeenCalledWith(
+      listing.id,
+      { rent: 700 },
+      "507f1f77bcf86cd799439099",
+    );
   });
 
   it("returns a structured not-found error when updating a missing listing", async () => {
@@ -156,6 +172,28 @@ describe("local listing write APIs", () => {
       error: {
         code: "LISTING_NOT_FOUND",
         status: 404,
+      },
+    });
+  });
+
+  it("returns FORBIDDEN when updating another user's listing", async () => {
+    vi.mocked(updateListing).mockRejectedValue(
+      forbidden("Only the listing owner can update this listing."),
+    );
+
+    const response = await PATCH(
+      new Request("http://localhost:3000/api/listings/507f1f77bcf86cd799439011", {
+        method: "PATCH",
+        body: JSON.stringify({ rent: 700 }),
+      }),
+      { params: Promise.resolve({ id: listing.id }) },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "FORBIDDEN",
+        status: 403,
       },
     });
   });
@@ -182,6 +220,34 @@ describe("local listing write APIs", () => {
         },
       },
     });
-    expect(archiveListing).toHaveBeenCalledWith(listing.id);
+    expect(archiveListing).toHaveBeenCalledWith(
+      listing.id,
+      "507f1f77bcf86cd799439099",
+    );
+  });
+
+  it("returns AUTH_REQUIRED when creating without a session", async () => {
+    vi.mocked(requireCurrentUser).mockRejectedValue(authRequired());
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/listings", {
+        method: "POST",
+        body: JSON.stringify({
+          title: listing.title,
+          type: listing.type,
+          description: listing.description,
+          rent: listing.rent,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "AUTH_REQUIRED",
+        status: 401,
+      },
+    });
+    expect(createListing).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/auth/password.test.ts
+++ b/apps/web/src/features/auth/password.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { hashPassword, verifyPassword } from "@/features/auth/password";
+
+describe("password helpers", () => {
+  it("hashes and verifies passwords", async () => {
+    const hash = await hashPassword("Password1");
+
+    expect(hash).not.toBe("Password1");
+    await expect(verifyPassword("Password1", hash)).resolves.toBe(true);
+    await expect(verifyPassword("Wrongpass1", hash)).resolves.toBe(false);
+  });
+});

--- a/apps/web/src/features/auth/password.ts
+++ b/apps/web/src/features/auth/password.ts
@@ -1,0 +1,11 @@
+import bcrypt from "bcryptjs";
+
+const SALT_ROUNDS = 12;
+
+export async function hashPassword(password: string) {
+  return bcrypt.hash(password, SALT_ROUNDS);
+}
+
+export async function verifyPassword(password: string, passwordHash: string) {
+  return bcrypt.compare(password, passwordHash);
+}

--- a/apps/web/src/features/auth/schemas.test.ts
+++ b/apps/web/src/features/auth/schemas.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  loginBodySchema,
+  registerBodySchema,
+  safeUserSchema,
+} from "@/features/auth/schemas";
+
+describe("auth schemas", () => {
+  it("normalizes registration email and validates password strength", () => {
+    const parsed = registerBodySchema.parse({
+      email: "USER@Example.COM ",
+      name: "Kushal",
+      password: "Password1",
+    });
+
+    expect(parsed).toEqual({
+      email: "user@example.com",
+      name: "Kushal",
+      password: "Password1",
+    });
+  });
+
+  it("rejects weak passwords", () => {
+    const parsed = registerBodySchema.safeParse({
+      email: "user@example.com",
+      name: "Kushal",
+      password: "password",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("normalizes login email", () => {
+    const parsed = loginBodySchema.parse({
+      email: "USER@Example.COM ",
+      password: "Password1",
+    });
+
+    expect(parsed.email).toBe("user@example.com");
+  });
+
+  it("omits password hashes from safe user responses", () => {
+    const parsed = safeUserSchema.parse({
+      id: "507f1f77bcf86cd799439011",
+      email: "user@example.com",
+      name: "Kushal",
+      image: null,
+    });
+
+    expect(parsed).not.toHaveProperty("passwordHash");
+  });
+});

--- a/apps/web/src/features/auth/schemas.ts
+++ b/apps/web/src/features/auth/schemas.ts
@@ -1,0 +1,38 @@
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+
+extendZodWithOpenApi(z);
+
+const passwordSchema = z
+  .string()
+  .min(8, "Password must be at least 8 characters.")
+  .max(72, "Password must be at most 72 characters.")
+  .regex(/[a-z]/, "Password must include a lowercase letter.")
+  .regex(/[A-Z]/, "Password must include an uppercase letter.")
+  .regex(/[0-9]/, "Password must include a number.");
+
+export const registerBodySchema = z.object({
+  email: z.string().trim().toLowerCase().email(),
+  name: z.string().trim().min(2, "Name must be at least 2 characters.").max(80),
+  password: passwordSchema,
+});
+
+export const loginBodySchema = z.object({
+  email: z.string().trim().toLowerCase().email(),
+  password: z.string().min(1, "Password is required."),
+});
+
+export const safeUserSchema = z.object({
+  id: z.string(),
+  email: z.string().email(),
+  name: z.string().nullable(),
+  image: z.string().nullable(),
+});
+
+export const registerResponseSchema = z.object({
+  user: safeUserSchema,
+});
+
+export type RegisterInput = z.infer<typeof registerBodySchema>;
+export type LoginInput = z.infer<typeof loginBodySchema>;
+export type SafeUser = z.infer<typeof safeUserSchema>;

--- a/apps/web/src/features/auth/users.test.ts
+++ b/apps/web/src/features/auth/users.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { hashPassword } from "@/features/auth/password";
+import { registerUser, validateCredentials } from "@/features/auth/users";
+import { prisma } from "@/server/db/prisma";
+
+vi.mock("@/server/db/prisma", () => ({
+  prisma: {
+    user: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+describe("auth user helpers", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.user.create).mockReset();
+    vi.mocked(prisma.user.findUnique).mockReset();
+  });
+
+  it("registers a user with a password hash", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.user.create).mockResolvedValue({
+      id: "507f1f77bcf86cd799439011",
+      email: "user@example.com",
+      name: "Kushal",
+      image: null,
+      passwordHash: "hash",
+      createdAt: new Date("2026-05-18T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-18T12:00:00.000Z"),
+    });
+
+    const user = await registerUser({
+      email: "user@example.com",
+      name: "Kushal",
+      password: "Password1",
+    });
+
+    expect(user).toEqual({
+      id: "507f1f77bcf86cd799439011",
+      email: "user@example.com",
+      name: "Kushal",
+      image: null,
+    });
+    expect(prisma.user.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        email: "user@example.com",
+        name: "Kushal",
+        passwordHash: expect.any(String),
+      }),
+    });
+  });
+
+  it("rejects duplicate email registration", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "507f1f77bcf86cd799439011",
+      email: "user@example.com",
+      name: "Kushal",
+      image: null,
+      passwordHash: "hash",
+      createdAt: new Date("2026-05-18T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-18T12:00:00.000Z"),
+    });
+
+    await expect(
+      registerUser({
+        email: "user@example.com",
+        name: "Kushal",
+        password: "Password1",
+      }),
+    ).rejects.toMatchObject({
+      code: "EMAIL_ALREADY_EXISTS",
+      status: 409,
+    });
+  });
+
+  it("validates credentials against the stored hash", async () => {
+    const passwordHash = await hashPassword("Password1");
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "507f1f77bcf86cd799439011",
+      email: "user@example.com",
+      name: "Kushal",
+      image: null,
+      passwordHash,
+      createdAt: new Date("2026-05-18T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-18T12:00:00.000Z"),
+    });
+
+    const user = await validateCredentials({
+      email: "user@example.com",
+      password: "Password1",
+    });
+
+    expect(user?.email).toBe("user@example.com");
+  });
+});

--- a/apps/web/src/features/auth/users.ts
+++ b/apps/web/src/features/auth/users.ts
@@ -1,0 +1,62 @@
+import { type User } from "@prisma/client";
+
+import {
+  type LoginInput,
+  type RegisterInput,
+  type SafeUser,
+  safeUserSchema,
+} from "@/features/auth/schemas";
+import { hashPassword, verifyPassword } from "@/features/auth/password";
+import { emailAlreadyExists } from "@/server/api/errors";
+import { prisma } from "@/server/db/prisma";
+
+function toSafeUser(user: Pick<User, "id" | "email" | "name" | "image">): SafeUser {
+  return safeUserSchema.parse({
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    image: user.image,
+  });
+}
+
+export async function registerUser(input: RegisterInput) {
+  const existingUser = await prisma.user.findUnique({
+    where: {
+      email: input.email,
+    },
+  });
+
+  if (existingUser) {
+    throw emailAlreadyExists(input.email);
+  }
+
+  const user = await prisma.user.create({
+    data: {
+      email: input.email,
+      name: input.name,
+      passwordHash: await hashPassword(input.password),
+    },
+  });
+
+  return toSafeUser(user);
+}
+
+export async function validateCredentials(input: LoginInput) {
+  const user = await prisma.user.findUnique({
+    where: {
+      email: input.email,
+    },
+  });
+
+  if (!user?.passwordHash) {
+    return null;
+  }
+
+  const isValidPassword = await verifyPassword(input.password, user.passwordHash);
+
+  if (!isValidPassword) {
+    return null;
+  }
+
+  return toSafeUser(user);
+}

--- a/apps/web/src/features/listings/mutations.ts
+++ b/apps/web/src/features/listings/mutations.ts
@@ -5,23 +5,35 @@ import {
   type ListingUpdateInput,
   toListingWriteData,
 } from "@/features/listings/schemas";
+import { forbidden } from "@/server/api/errors";
 import { prisma } from "@/server/db/prisma";
 
 function hasDatabaseUrl() {
   return Boolean(process.env.DATABASE_URL);
 }
 
-export async function createListing(input: ListingCreateInput) {
+export async function createListing(input: ListingCreateInput, ownerId: string) {
   if (!hasDatabaseUrl()) {
     return null;
   }
 
   return prisma.listing.create({
-    data: toListingWriteData(input) as Prisma.ListingCreateInput,
+    data: {
+      ...(toListingWriteData(input) as Prisma.ListingCreateInput),
+      owner: {
+        connect: {
+          id: ownerId,
+        },
+      },
+    },
   });
 }
 
-export async function updateListing(id: string, input: ListingUpdateInput) {
+export async function updateListing(
+  id: string,
+  input: ListingUpdateInput,
+  ownerId: string,
+) {
   if (!hasDatabaseUrl()) {
     return null;
   }
@@ -35,11 +47,16 @@ export async function updateListing(id: string, input: ListingUpdateInput) {
     },
     select: {
       id: true,
+      ownerId: true,
     },
   });
 
   if (!existing) {
     return null;
+  }
+
+  if (existing.ownerId !== ownerId) {
+    throw forbidden("Only the listing owner can update this listing.");
   }
 
   return prisma.listing.update({
@@ -48,8 +65,12 @@ export async function updateListing(id: string, input: ListingUpdateInput) {
   });
 }
 
-export async function archiveListing(id: string) {
-  return updateListing(id, {
-    status: ListingStatus.ARCHIVED,
-  });
+export async function archiveListing(id: string, ownerId: string) {
+  return updateListing(
+    id,
+    {
+      status: ListingStatus.ARCHIVED,
+    },
+    ownerId,
+  );
 }

--- a/apps/web/src/server/api/errors.ts
+++ b/apps/web/src/server/api/errors.ts
@@ -1,8 +1,10 @@
 export type ApiErrorCode =
   | "BAD_REQUEST"
   | "VALIDATION_ERROR"
+  | "AUTH_REQUIRED"
+  | "FORBIDDEN"
+  | "EMAIL_ALREADY_EXISTS"
   | "LISTING_NOT_FOUND"
-  | "LOCAL_ONLY_ENDPOINT"
   | "INTERNAL_SERVER_ERROR";
 
 export type ApiErrorInit = {
@@ -76,19 +78,36 @@ export function badRequest(message: string, details: Record<string, unknown> = {
   });
 }
 
+export function authRequired() {
+  return new ApiError({
+    code: "AUTH_REQUIRED",
+    message: "You must be signed in to perform this action.",
+    status: 401,
+  });
+}
+
+export function forbidden(message = "You do not have permission to perform this action.") {
+  return new ApiError({
+    code: "FORBIDDEN",
+    message,
+    status: 403,
+  });
+}
+
+export function emailAlreadyExists(email: string) {
+  return new ApiError({
+    code: "EMAIL_ALREADY_EXISTS",
+    message: "An account already exists for this email address.",
+    status: 409,
+    details: { email },
+  });
+}
+
 export function listingNotFound(id: string) {
   return new ApiError({
     code: "LISTING_NOT_FOUND",
     message: "Listing was not found.",
     status: 404,
     details: { id },
-  });
-}
-
-export function localOnlyEndpoint() {
-  return new ApiError({
-    code: "LOCAL_ONLY_ENDPOINT",
-    message: "This endpoint is enabled only for local development.",
-    status: 403,
   });
 }

--- a/apps/web/src/server/api/local-only.ts
+++ b/apps/web/src/server/api/local-only.ts
@@ -1,7 +1,0 @@
-import { localOnlyEndpoint } from "@/server/api/errors";
-
-export function assertLocalWriteApiAllowed() {
-  if (process.env.NODE_ENV === "production") {
-    throw localOnlyEndpoint();
-  }
-}

--- a/apps/web/src/server/api/openapi.test.ts
+++ b/apps/web/src/server/api/openapi.test.ts
@@ -7,11 +7,15 @@ describe("OpenAPI document", () => {
     const document = createOpenApiDocument();
 
     expect(document.openapi).toBe("3.0.0");
+    expect(document.paths["/api/auth/register"]?.post).toBeDefined();
     expect(document.paths["/api/listings"]?.get).toBeDefined();
     expect(document.paths["/api/listings"]?.post).toBeDefined();
     expect(document.paths["/api/listings/{id}"]?.get).toBeDefined();
     expect(document.paths["/api/listings/{id}"]?.patch).toBeDefined();
     expect(document.paths["/api/listings/{id}"]?.delete).toBeDefined();
     expect(document.components?.schemas?.ApiErrorResponse).toBeDefined();
+    expect(document.components?.schemas?.RegisterResponse).toBeDefined();
+    expect(document.paths["/api/listings"]?.post?.responses?.[401]).toBeDefined();
+    expect(document.paths["/api/listings/{id}"]?.patch?.responses?.[403]).toBeDefined();
   });
 });

--- a/apps/web/src/server/api/openapi.ts
+++ b/apps/web/src/server/api/openapi.ts
@@ -6,6 +6,10 @@ import {
 import { z } from "zod";
 
 import {
+  registerBodySchema,
+  registerResponseSchema,
+} from "@/features/auth/schemas";
+import {
   listingCreateBodySchema,
   listingDetailResponseSchema,
   listingParamsSchema,
@@ -51,10 +55,29 @@ export function createOpenApiDocument() {
   const registry = new OpenAPIRegistry();
 
   registry.register("ApiErrorResponse", apiErrorResponseSchema);
+  registry.register("RegisterBody", registerBodySchema);
+  registry.register("RegisterResponse", registerResponseSchema);
   registry.register("ListingCreateBody", listingCreateBodySchema);
   registry.register("ListingUpdateBody", listingUpdateBodySchema);
   registry.register("ListingsResponse", listingsResponseSchema);
   registry.register("ListingDetailResponse", listingDetailResponseSchema);
+
+  registry.registerPath({
+    method: "post",
+    path: "/api/auth/register",
+    summary: "Register with email and password",
+    description:
+      "Creates a local credentials account. Use the Auth.js credentials sign-in flow after registration to create a session.",
+    request: {
+      body: jsonRequestBody(registerBodySchema, "Registration payload."),
+    },
+    responses: {
+      201: jsonContent(registerResponseSchema, "Registered user response."),
+      400: jsonContent(apiErrorResponseSchema, "Validation error response."),
+      409: jsonContent(apiErrorResponseSchema, "Duplicate email response."),
+      500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
+    },
+  });
 
   registry.registerPath({
     method: "get",
@@ -76,14 +99,14 @@ export function createOpenApiDocument() {
     path: "/api/listings",
     summary: "Create listing",
     description:
-      "Local/dev-only endpoint for creating listings before authentication is added.",
+      "Creates a listing for the signed-in user.",
     request: {
       body: jsonRequestBody(listingCreateBodySchema, "Listing create payload."),
     },
     responses: {
       201: jsonContent(listingDetailResponseSchema, "Created listing response."),
       400: jsonContent(apiErrorResponseSchema, "Validation error response."),
-      403: jsonContent(apiErrorResponseSchema, "Local-only endpoint response."),
+      401: jsonContent(apiErrorResponseSchema, "Authentication required response."),
       500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
     },
   });
@@ -109,7 +132,7 @@ export function createOpenApiDocument() {
     path: "/api/listings/{id}",
     summary: "Update listing",
     description:
-      "Local/dev-only endpoint for updating listings before authentication is added.",
+      "Updates a listing owned by the signed-in user.",
     request: {
       params: listingParamsSchema,
       body: jsonRequestBody(listingUpdateBodySchema, "Listing update payload."),
@@ -117,7 +140,8 @@ export function createOpenApiDocument() {
     responses: {
       200: jsonContent(listingDetailResponseSchema, "Updated listing response."),
       400: jsonContent(apiErrorResponseSchema, "Validation error response."),
-      403: jsonContent(apiErrorResponseSchema, "Local-only endpoint response."),
+      401: jsonContent(apiErrorResponseSchema, "Authentication required response."),
+      403: jsonContent(apiErrorResponseSchema, "Forbidden owner-check response."),
       404: jsonContent(apiErrorResponseSchema, "Listing not found response."),
       500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
     },
@@ -128,14 +152,15 @@ export function createOpenApiDocument() {
     path: "/api/listings/{id}",
     summary: "Archive listing",
     description:
-      "Local/dev-only endpoint that soft-archives a listing before authentication is added.",
+      "Soft-archives a listing owned by the signed-in user.",
     request: {
       params: listingParamsSchema,
     },
     responses: {
       200: jsonContent(listingDetailResponseSchema, "Archived listing response."),
       400: jsonContent(apiErrorResponseSchema, "Validation error response."),
-      403: jsonContent(apiErrorResponseSchema, "Local-only endpoint response."),
+      401: jsonContent(apiErrorResponseSchema, "Authentication required response."),
+      403: jsonContent(apiErrorResponseSchema, "Forbidden owner-check response."),
       404: jsonContent(apiErrorResponseSchema, "Listing not found response."),
       500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
     },

--- a/apps/web/src/server/auth/auth.ts
+++ b/apps/web/src/server/auth/auth.ts
@@ -1,0 +1,44 @@
+import NextAuth from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+
+import { loginBodySchema } from "@/features/auth/schemas";
+import { validateCredentials } from "@/features/auth/users";
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  session: {
+    strategy: "jwt",
+  },
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        const parsed = loginBodySchema.safeParse(credentials);
+
+        if (!parsed.success) {
+          return null;
+        }
+
+        return validateCredentials(parsed.data);
+      },
+    }),
+  ],
+  callbacks: {
+    jwt({ token, user }) {
+      if (user?.id) {
+        token.sub = user.id;
+      }
+
+      return token;
+    },
+    session({ session, token }) {
+      if (session.user && token.sub) {
+        session.user.id = token.sub;
+      }
+
+      return session;
+    },
+  },
+});

--- a/apps/web/src/server/auth/current-user.test.ts
+++ b/apps/web/src/server/auth/current-user.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { requireCurrentUser } from "@/server/auth/current-user";
+
+vi.mock("@/server/auth/auth", () => ({
+  auth: vi.fn(),
+}));
+
+import { auth } from "@/server/auth/auth";
+
+describe("requireCurrentUser", () => {
+  it("returns the signed-in user id", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "507f1f77bcf86cd799439011",
+        email: "user@example.com",
+        name: "Kushal",
+      },
+      expires: "2026-05-19T12:00:00.000Z",
+    });
+
+    await expect(requireCurrentUser()).resolves.toEqual({
+      id: "507f1f77bcf86cd799439011",
+      email: "user@example.com",
+      name: "Kushal",
+    });
+  });
+
+  it("throws AUTH_REQUIRED when there is no session", async () => {
+    vi.mocked(auth).mockResolvedValue(null);
+
+    await expect(requireCurrentUser()).rejects.toMatchObject({
+      code: "AUTH_REQUIRED",
+      status: 401,
+    });
+  });
+});

--- a/apps/web/src/server/auth/current-user.ts
+++ b/apps/web/src/server/auth/current-user.ts
@@ -1,0 +1,22 @@
+import { auth } from "@/server/auth/auth";
+import { authRequired } from "@/server/api/errors";
+
+export type CurrentUser = {
+  id: string;
+  email?: string | null;
+  name?: string | null;
+};
+
+export async function requireCurrentUser(): Promise<CurrentUser> {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    throw authRequired();
+  }
+
+  return {
+    id: session.user.id,
+    email: session.user.email,
+    name: session.user.name,
+  };
+}

--- a/apps/web/src/types/next-auth.d.ts
+++ b/apps/web/src/types/next-auth.d.ts
@@ -1,0 +1,16 @@
+import "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+      email?: string | null;
+      name?: string | null;
+      image?: string | null;
+    };
+  }
+
+  interface User {
+    id: string;
+  }
+}

--- a/docs/superpowers/plans/2026-05-18-auth-foundation.md
+++ b/docs/superpowers/plans/2026-05-18-auth-foundation.md
@@ -1,0 +1,36 @@
+# Auth Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add email/password authentication and protect listing write APIs with session and owner checks.
+
+**Architecture:** Use Auth.js / NextAuth credentials with JWT sessions. Registration is a first-party API endpoint that validates input, hashes passwords, and creates users. Listing route handlers use a current-user helper instead of the temporary local-only guard.
+
+**Tech Stack:** Next.js App Router, Auth.js / NextAuth, Prisma MongoDB, Zod, bcryptjs, Vitest.
+
+---
+
+## File Structure
+
+- Modify `apps/web/prisma/schema.prisma`: add `User.passwordHash`.
+- Create `apps/web/src/features/auth/schemas.ts`: registration and safe user schemas.
+- Create `apps/web/src/features/auth/password.ts`: password hash/verify helpers.
+- Create `apps/web/src/features/auth/users.ts`: register and lookup helpers.
+- Create `apps/web/src/server/auth/auth.ts`: Auth.js config and exported handlers/auth helpers.
+- Create `apps/web/src/app/api/auth/[...nextauth]/route.ts`: Auth.js route handler.
+- Create `apps/web/src/app/api/auth/register/route.ts`: registration endpoint.
+- Create `apps/web/src/server/auth/current-user.ts`: `requireCurrentUser`.
+- Modify listing route handlers and mutations to set/check `ownerId`.
+- Modify API errors and OpenAPI docs for auth errors.
+- Add focused tests beside auth and listing modules.
+
+## Tasks
+
+- [x] Add Prisma password field and regenerate Prisma client.
+- [x] Add Auth.js credentials configuration.
+- [x] Add password hashing and registration helpers.
+- [x] Add registration API and OpenAPI docs.
+- [x] Add current-user helper and auth errors.
+- [x] Replace local-only listing write guard with session ownership checks.
+- [x] Update tests for registration, auth-required, forbidden, and owner writes.
+- [x] Run `npm test`, `npm run lint`, and `npm run build`.

--- a/docs/superpowers/specs/2026-05-18-auth-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-18-auth-foundation-design.md
@@ -1,0 +1,87 @@
+# Auth Foundation Design
+
+Date: 2026-05-18
+
+## Goal
+
+Add email/password authentication to the Next.js migration so users can create accounts, sign in locally, and own listing writes. This replaces the temporary local-only API guard with real session and ownership checks.
+
+## Scope
+
+This slice covers:
+
+- credentials-based registration with email, name, and password;
+- credentials-based login through Auth.js / NextAuth;
+- password hashing with `bcryptjs`;
+- Prisma user fields for password auth;
+- server-side current-user helper;
+- structured `AUTH_REQUIRED`, `FORBIDDEN`, and duplicate email errors;
+- protected listing create/update/archive APIs;
+- Swagger/OpenAPI updates for auth-related responses and registration;
+- tests for password validation, registration, auth errors, and owner checks.
+
+This slice does not cover:
+
+- OAuth providers such as GitHub, Google, or Facebook;
+- password reset;
+- email verification;
+- UI login/register pages beyond API support;
+- production mail delivery.
+
+## Architecture
+
+Auth.js owns session creation and session reading. Credentials login validates the submitted email/password against our Prisma `User.passwordHash`. Registration is a normal API endpoint because Auth.js credentials provider signs in existing users but does not create accounts.
+
+```text
+register API -> validate body -> hash password -> create user -> user response
+login form/Auth.js -> credentials provider -> compare password -> JWT session
+listing write API -> requireCurrentUser -> mutation with ownerId / owner check
+```
+
+Use JWT sessions for the first slice. This keeps the Prisma schema small and avoids adding adapter tables before OAuth providers are introduced.
+
+## Data Model
+
+Extend `User` with:
+
+- `passwordHash String?`
+
+Existing fields remain:
+
+- `id`
+- `email`
+- `name`
+- `image`
+- `listings`
+- timestamps
+
+`passwordHash` is nullable so future OAuth-only users can exist without a password.
+
+## API Contracts
+
+Registration endpoint:
+
+- `POST /api/auth/register`
+- body: `{ "email": "...", "name": "...", "password": "..." }`
+- response: `{ "data": { "user": { "id": "...", "email": "...", "name": "..." } } }`
+
+Structured auth errors:
+
+- `AUTH_REQUIRED`: `401`
+- `FORBIDDEN`: `403`
+- `EMAIL_ALREADY_EXISTS`: `409`
+- `INVALID_CREDENTIALS`: login failure inside the credentials provider
+
+Listing write behavior:
+
+- `POST /api/listings` requires a signed-in user and sets `ownerId`.
+- `PATCH /api/listings/{id}` requires the signed-in user to own the listing.
+- `DELETE /api/listings/{id}` requires the signed-in user to own the listing and soft-archives it.
+
+## Testing
+
+Use Vitest unit and route tests. Mock Auth.js session access for route tests so they do not need browser cookies. Continue running:
+
+- `npm test`
+- `npm run lint`
+- `npm run build`


### PR DESCRIPTION
## Summary

Adds the email/password authentication foundation for the Next.js migration:

- Auth.js / NextAuth credentials route at `/api/auth/[...nextauth]`
- registration endpoint at `POST /api/auth/register`
- password hashing with `bcryptjs`
- `User.passwordHash` in Prisma
- current-user helper for protected APIs
- `AUTH_REQUIRED`, `FORBIDDEN`, and `EMAIL_ALREADY_EXISTS` structured errors
- listing writes now require a signed-in user and enforce owner checks
- OpenAPI/Swagger docs updated for registration and auth responses
- focused tests for auth schemas, password hashing, registration, current user, and protected listing writes

## Notes

Email verification and password reset are intentionally left for after the migration basics. OAuth providers can be added later without changing the credentials foundation.

## Validation

- `npm test` from `apps/web`: 32 tests passing
- `npm run lint` from `apps/web`: passing
- `npm run build` from `apps/web`: passing
- Live check: unauthenticated `POST /api/listings` returns `401 AUTH_REQUIRED`
- Live check: `POST /api/auth/register` creates a user after Prisma client regeneration/restart

`.DS_Store` remains unstaged and is not included in this PR.