### PR TITLE
Add profile dashboard and listing filters

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -20,11 +20,21 @@ enum ListingStatus {
   ARCHIVED
 }
 
+enum PetPolicy {
+  UNKNOWN
+  NO_PETS
+  CATS_ONLY
+  DOGS_ONLY
+  PETS_ALLOWED
+}
+
 model User {
   id           String    @id @default(auto()) @map("_id") @db.ObjectId
   email        String    @unique
   name         String?
   image        String?
+  contactEmail String?
+  contactPhone String?
   passwordHash String?
   listings     Listing[]
   createdAt    DateTime  @default(now())
@@ -48,6 +58,7 @@ model Listing {
   contactPhone      String?
   bedrooms          Int?
   bathrooms         Float?
+  petPolicy         PetPolicy     @default(UNKNOWN)
   amenities         String[]
   imageUrls         String[]
   ownerId           String?       @db.ObjectId
@@ -60,4 +71,10 @@ model Listing {
   @@index([rent])
   @@index([availableFrom])
   @@index([ownerId])
+  @@index([status, type])
+  @@index([status, rent])
+  @@index([status, bedrooms])
+  @@index([status, bathrooms])
+  @@index([status, availableFrom])
+  @@index([status, petPolicy])
 }

--- a/apps/web/src/app/api/listings/[id]/route.test.ts
+++ b/apps/web/src/app/api/listings/[id]/route.test.ts
@@ -28,6 +28,7 @@ const listing = {
   contactPhone: null,
   bedrooms: 1,
   bathrooms: 1,
+  petPolicy: "UNKNOWN" as const,
   amenities: ["Laundry"],
   imageUrls: [],
   ownerId: null,

--- a/apps/web/src/app/api/listings/route.test.ts
+++ b/apps/web/src/app/api/listings/route.test.ts
@@ -28,6 +28,7 @@ const listing = {
   contactPhone: null,
   bedrooms: 1,
   bathrooms: 1,
+  petPolicy: "PETS_ALLOWED" as const,
   amenities: ["Laundry"],
   imageUrls: [],
   ownerId: null,
@@ -60,7 +61,36 @@ describe("GET /api/listings", () => {
       },
     });
     expect(response.status).toBe(200);
-    expect(getActiveListings).toHaveBeenCalledWith("ROOM");
+    expect(getActiveListings).toHaveBeenCalledWith({
+      type: "ROOM",
+      rentMin: undefined,
+      rentMax: undefined,
+      bedroomsMin: undefined,
+      bathroomsMin: undefined,
+      availableBy: undefined,
+      petPolicy: undefined,
+    });
+  });
+
+  it("passes structured discovery filters to listing reads", async () => {
+    vi.mocked(getActiveListings).mockResolvedValue([listing]);
+
+    const response = await GET(
+      new Request(
+        "http://localhost:3000/api/listings?type=ROOM&rentMin=700&rentMax=1200&bedroomsMin=1&bathroomsMin=1.5&availableBy=2026-08-01&petPolicy=PETS_ALLOWED",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getActiveListings).toHaveBeenCalledWith({
+      type: "ROOM",
+      rentMin: 700,
+      rentMax: 1200,
+      bedroomsMin: 1,
+      bathroomsMin: 1.5,
+      availableBy: "2026-08-01",
+      petPolicy: "PETS_ALLOWED",
+    });
   });
 
   it("returns a validation error for unsupported filters", async () => {

--- a/apps/web/src/app/api/listings/route.ts
+++ b/apps/web/src/app/api/listings/route.ts
@@ -1,5 +1,3 @@
-import { ListingType } from "@prisma/client";
-
 import {
   listingCreateBodySchema,
   listingQuerySchema,
@@ -19,10 +17,16 @@ export async function GET(request: Request) {
     const query = throwIfInvalid(
       listingQuerySchema.safeParse({
         type: url.searchParams.get("type") ?? undefined,
+        rentMin: url.searchParams.get("rentMin") ?? undefined,
+        rentMax: url.searchParams.get("rentMax") ?? undefined,
+        bedroomsMin: url.searchParams.get("bedroomsMin") ?? undefined,
+        bathroomsMin: url.searchParams.get("bathroomsMin") ?? undefined,
+        availableBy: url.searchParams.get("availableBy") ?? undefined,
+        petPolicy: url.searchParams.get("petPolicy") ?? undefined,
       }),
     );
 
-    const listings = await getActiveListings(query.type as ListingType | undefined);
+    const listings = await getActiveListings(query);
 
     return apiData({
       listings: listings.map(serializeListing),

--- a/apps/web/src/app/api/listings/write-routes.test.ts
+++ b/apps/web/src/app/api/listings/write-routes.test.ts
@@ -40,6 +40,7 @@ const listing = {
   distanceToCampus: "0.5 miles",
   bedrooms: 1,
   bathrooms: 1,
+  petPolicy: "UNKNOWN" as const,
   amenities: ["Laundry"],
   imageUrls: [],
   ownerId: null,

--- a/apps/web/src/app/api/profile/route.test.ts
+++ b/apps/web/src/app/api/profile/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PATCH } from "@/app/api/profile/route";
+import { updateProfileUser } from "@/features/profile/mutations";
+import { requireCurrentUser } from "@/server/auth/current-user";
+
+vi.mock("@/features/profile/mutations", () => ({
+  updateProfileUser: vi.fn(),
+}));
+
+vi.mock("@/server/auth/current-user", () => ({
+  requireCurrentUser: vi.fn(),
+}));
+
+describe("PATCH /api/profile", () => {
+  beforeEach(() => {
+    vi.mocked(updateProfileUser).mockReset();
+    vi.mocked(requireCurrentUser).mockResolvedValue({
+      id: "507f1f77bcf86cd799439099",
+      email: "owner@example.com",
+      name: "Owner Name",
+    });
+  });
+
+  it("updates profile account basics for the signed-in user", async () => {
+    vi.mocked(updateProfileUser).mockResolvedValue({
+      id: "507f1f77bcf86cd799439099",
+      email: "owner@example.com",
+      name: "Kushal Singh",
+      contactEmail: "renter@example.com",
+      contactPhone: "320-555-1212",
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+
+    const response = await PATCH(
+      new Request("http://localhost:3000/api/profile", {
+        method: "PATCH",
+        body: JSON.stringify({
+          name: "Kushal Singh",
+          contactEmail: "renter@example.com",
+          contactPhone: "320-555-1212",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        user: {
+          id: "507f1f77bcf86cd799439099",
+          name: "Kushal Singh",
+          contactEmail: "renter@example.com",
+          contactPhone: "320-555-1212",
+        },
+      },
+    });
+    expect(updateProfileUser).toHaveBeenCalledWith(
+      "507f1f77bcf86cd799439099",
+      {
+        name: "Kushal Singh",
+        contactEmail: "renter@example.com",
+        contactPhone: "320-555-1212",
+      },
+    );
+  });
+
+  it("returns validation errors for invalid contact defaults", async () => {
+    const response = await PATCH(
+      new Request("http://localhost:3000/api/profile", {
+        method: "PATCH",
+        body: JSON.stringify({
+          contactEmail: "not-an-email",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "VALIDATION_ERROR",
+        status: 400,
+      },
+    });
+    expect(updateProfileUser).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/profile/route.ts
+++ b/apps/web/src/app/api/profile/route.ts
@@ -1,0 +1,19 @@
+import { updateProfileUser } from "@/features/profile/mutations";
+import { profileUpdateBodySchema } from "@/features/profile/schemas";
+import { readJsonBody } from "@/server/api/request";
+import { apiData, throwIfInvalid, withApiErrorHandling } from "@/server/api/responses";
+import { requireCurrentUser } from "@/server/auth/current-user";
+
+export async function PATCH(request: Request) {
+  return withApiErrorHandling(async () => {
+    const currentUser = await requireCurrentUser();
+    const body = throwIfInvalid(
+      profileUpdateBodySchema.safeParse(await readJsonBody(request)),
+    );
+    const user = await updateProfileUser(currentUser.id, body);
+
+    return apiData({
+      user,
+    });
+  });
+}

--- a/apps/web/src/app/app-nav.test.tsx
+++ b/apps/web/src/app/app-nav.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AppNav } from "@/app/app-nav";
+import { auth } from "@/server/auth/auth";
+
+vi.mock("@/server/auth/auth", () => ({
+  auth: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+function hasHref(node: unknown, href: string): boolean {
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const element = node as {
+    props?: { href?: unknown; children?: unknown };
+  };
+
+  if (element.props?.href === href) {
+    return true;
+  }
+
+  const children = element.props?.children;
+
+  if (Array.isArray(children)) {
+    return children.some((child) => hasHref(child, href));
+  }
+
+  return hasHref(children, href);
+}
+
+describe("AppNav", () => {
+  it("shows a profile link for signed-in users", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "507f1f77bcf86cd799439099",
+      },
+      expires: "2026-06-01T00:00:00.000Z",
+    });
+
+    const nav = await AppNav();
+
+    expect(hasHref(nav, "/profile")).toBe(true);
+  });
+
+  it("does not show a profile link for signed-out users", async () => {
+    vi.mocked(auth).mockResolvedValue(null);
+
+    const nav = await AppNav();
+
+    expect(hasHref(nav, "/profile")).toBe(false);
+  });
+});

--- a/apps/web/src/app/app-nav.tsx
+++ b/apps/web/src/app/app-nav.tsx
@@ -19,19 +19,24 @@ export async function AppNav() {
             Post
           </Link>
           {session?.user ? (
-            <form
-              action={async () => {
-                "use server";
-                await signOut({ redirectTo: "/" });
-              }}
-            >
-              <button
-                type="submit"
-                className="rounded-md border border-zinc-300 px-3 py-1.5 text-zinc-950 hover:bg-zinc-100"
+            <>
+              <Link href="/profile" className="text-zinc-700 hover:text-zinc-950">
+                Profile
+              </Link>
+              <form
+                action={async () => {
+                  "use server";
+                  await signOut({ redirectTo: "/" });
+                }}
               >
-                Sign out
-              </button>
-            </form>
+                <button
+                  type="submit"
+                  className="rounded-md border border-zinc-300 px-3 py-1.5 text-zinc-950 hover:bg-zinc-100"
+                >
+                  Sign out
+                </button>
+              </form>
+            </>
           ) : (
             <Link
               href="/login"

--- a/apps/web/src/app/listings/new/page.test.tsx
+++ b/apps/web/src/app/listings/new/page.test.tsx
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
 import NewListingPage from "@/app/listings/new/page";
+import { getProfileUser } from "@/features/profile/queries";
 import { auth } from "@/server/auth/auth";
+
+vi.mock("@/features/profile/queries", () => ({
+  getProfileUser: vi.fn(),
+}));
 
 vi.mock("@/server/auth/auth", () => ({
   auth: vi.fn(),
@@ -20,5 +25,34 @@ describe("NewListingPage", () => {
     await expect(Promise.resolve().then(() => NewListingPage())).rejects.toThrow(
       "redirect:/login?callbackUrl=%2Flistings%2Fnew",
     );
+  });
+
+  it("uses profile contact defaults for new listing forms", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "507f1f77bcf86cd799439099",
+        email: "owner@example.com",
+      },
+      expires: "2026-06-01T00:00:00.000Z",
+    });
+    vi.mocked(getProfileUser).mockResolvedValue({
+      id: "507f1f77bcf86cd799439099",
+      email: "owner@example.com",
+      name: "Owner Name",
+      contactEmail: "renter@example.com",
+      contactPhone: "320-555-1212",
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+
+    const page = await NewListingPage();
+    const form = (page.props.children as unknown[]).at(-1) as {
+      props: {
+        defaultContactEmail?: string | null;
+        defaultContactPhone?: string | null;
+      };
+    };
+
+    expect(form.props.defaultContactEmail).toBe("renter@example.com");
+    expect(form.props.defaultContactPhone).toBe("320-555-1212");
   });
 });

--- a/apps/web/src/app/listings/new/page.tsx
+++ b/apps/web/src/app/listings/new/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { ListingCreateForm } from "@/features/listings/components/listing-create-form";
+import { getProfileUser } from "@/features/profile/queries";
 import { auth } from "@/server/auth/auth";
 
 export default async function NewListingPage() {
@@ -9,6 +10,8 @@ export default async function NewListingPage() {
   if (!session?.user?.id) {
     redirect("/login?callbackUrl=%2Flistings%2Fnew");
   }
+
+  const profileUser = await getProfileUser(session.user.id);
 
   return (
     <main className="mx-auto max-w-3xl px-6 py-10">
@@ -21,7 +24,10 @@ export default async function NewListingPage() {
       <p className="mt-4 leading-8 text-zinc-700">
         Add the essentials first. You can edit details after the post is live.
       </p>
-      <ListingCreateForm defaultContactEmail={session.user.email} />
+      <ListingCreateForm
+        defaultContactEmail={profileUser?.contactEmail ?? session.user.email}
+        defaultContactPhone={profileUser?.contactPhone}
+      />
     </main>
   );
 }

--- a/apps/web/src/app/listings/page.test.tsx
+++ b/apps/web/src/app/listings/page.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import ListingsPage from "@/app/listings/page";
+import { getActiveListings } from "@/features/listings/queries";
+
+vi.mock("@/features/listings/queries", () => ({
+  getActiveListings: vi.fn(),
+}));
+
+function includesText(node: unknown, text: string): boolean {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node).includes(text);
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const element = node as { props?: { children?: unknown } };
+  const children = element.props?.children;
+
+  if (Array.isArray(children)) {
+    return children.some((child) => includesText(child, text));
+  }
+
+  return includesText(children, text);
+}
+
+describe("ListingsPage", () => {
+  it("uses URL filters for active listing discovery", async () => {
+    vi.mocked(getActiveListings).mockResolvedValue([]);
+
+    const page = await ListingsPage({
+      searchParams: Promise.resolve({
+        type: "ROOM",
+        rentMin: "700",
+        rentMax: "1200",
+        bedroomsMin: "1",
+        bathroomsMin: "1.5",
+        availableBy: "2026-08-01",
+        petPolicy: "PETS_ALLOWED",
+      }),
+    });
+
+    expect(getActiveListings).toHaveBeenCalledWith({
+      type: "ROOM",
+      rentMin: 700,
+      rentMax: 1200,
+      bedroomsMin: 1,
+      bathroomsMin: 1.5,
+      availableBy: "2026-08-01",
+      petPolicy: "PETS_ALLOWED",
+    });
+    expect(includesText(page, "Min price")).toBe(true);
+    expect(includesText(page, "Pet policy")).toBe(true);
+  });
+});

--- a/apps/web/src/app/listings/page.tsx
+++ b/apps/web/src/app/listings/page.tsx
@@ -1,13 +1,41 @@
 import Link from "next/link";
 
+import { ListingFilterForm } from "@/features/listings/components/listing-filter-form";
 import { ListingCard } from "@/features/listings/components/listing-card";
 import { ListingEmptyState } from "@/features/listings/components/listing-empty-state";
 import { getActiveListings } from "@/features/listings/queries";
+import { listingQuerySchema, type ListingQueryInput } from "@/features/listings/schemas";
 
 export const dynamic = "force-dynamic";
 
-export default async function ListingsPage() {
-  const listings = await getActiveListings();
+type ListingsPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+async function parseListingFilters(
+  searchParams: ListingsPageProps["searchParams"],
+): Promise<ListingQueryInput> {
+  const params = (await searchParams) ?? {};
+  const parsed = listingQuerySchema.safeParse({
+    type: firstParam(params.type),
+    rentMin: firstParam(params.rentMin),
+    rentMax: firstParam(params.rentMax),
+    bedroomsMin: firstParam(params.bedroomsMin),
+    bathroomsMin: firstParam(params.bathroomsMin),
+    availableBy: firstParam(params.availableBy),
+    petPolicy: firstParam(params.petPolicy),
+  });
+
+  return parsed.success ? parsed.data : {};
+}
+
+export default async function ListingsPage({ searchParams }: ListingsPageProps) {
+  const filters = await parseListingFilters(searchParams);
+  const listings = await getActiveListings(filters);
 
   return (
     <main className="mx-auto max-w-6xl px-6 py-10">
@@ -25,6 +53,8 @@ export default async function ListingsPage() {
           Post listing
         </Link>
       </div>
+
+      {ListingFilterForm({ filters })}
 
       {listings.length === 0 ? (
         <ListingEmptyState />

--- a/apps/web/src/app/profile/page.test.tsx
+++ b/apps/web/src/app/profile/page.test.tsx
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+
+import ProfilePage from "@/app/profile/page";
+import { getListingsByOwner } from "@/features/listings/queries";
+import { getProfileUser } from "@/features/profile/queries";
+import { auth } from "@/server/auth/auth";
+
+vi.mock("@/features/listings/queries", () => ({
+  getListingsByOwner: vi.fn(),
+}));
+
+vi.mock("@/features/profile/queries", () => ({
+  getProfileUser: vi.fn(),
+}));
+
+vi.mock("@/server/auth/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`redirect:${url}`);
+  }),
+}));
+
+const ownerId = "507f1f77bcf86cd799439099";
+
+const ownedListings = [
+  {
+    id: "507f1f77bcf86cd799439011",
+    title: "Active room near SCSU",
+    type: "ROOM" as const,
+    status: "ACTIVE" as const,
+    description: "Walkable room with utilities included.",
+    rent: 650,
+    deposit: null,
+    utilitiesIncluded: true,
+    availableFrom: null,
+    leaseDuration: "12 months",
+    address: null,
+    distanceToCampus: "0.5 miles",
+    contactEmail: null,
+    contactPhone: null,
+    bedrooms: 1,
+    bathrooms: 1,
+    amenities: ["Laundry"],
+    imageUrls: [],
+    ownerId,
+    createdAt: new Date("2026-05-18T12:00:00.000Z"),
+    updatedAt: new Date("2026-05-19T12:00:00.000Z"),
+  },
+  {
+    id: "507f1f77bcf86cd799439012",
+    title: "Archived studio",
+    type: "APARTMENT" as const,
+    status: "ARCHIVED" as const,
+    description: "No longer available.",
+    rent: 900,
+    deposit: 900,
+    utilitiesIncluded: false,
+    availableFrom: null,
+    leaseDuration: null,
+    address: null,
+    distanceToCampus: null,
+    contactEmail: null,
+    contactPhone: null,
+    bedrooms: 0,
+    bathrooms: 1,
+    amenities: [],
+    imageUrls: [],
+    ownerId,
+    createdAt: new Date("2026-05-18T12:00:00.000Z"),
+    updatedAt: new Date("2026-05-20T12:00:00.000Z"),
+  },
+];
+
+function includesText(node: unknown, text: string): boolean {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node).includes(text);
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const element = node as { props?: { children?: unknown } };
+  const children = element.props?.children;
+
+  if (Array.isArray(children)) {
+    return children.some((child) => includesText(child, text));
+  }
+
+  return includesText(children, text);
+}
+
+function hasHref(node: unknown, href: string): boolean {
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const element = node as {
+    props?: { href?: unknown; children?: unknown };
+  };
+
+  if (element.props?.href === href) {
+    return true;
+  }
+
+  const children = element.props?.children;
+
+  if (Array.isArray(children)) {
+    return children.some((child) => hasHref(child, href));
+  }
+
+  return hasHref(children, href);
+}
+
+describe("ProfilePage", () => {
+  it("redirects signed-out users to login with a callback", async () => {
+    vi.mocked(auth).mockResolvedValue(null);
+
+    await expect(Promise.resolve().then(() => ProfilePage())).rejects.toThrow(
+      "redirect:/login?callbackUrl=%2Fprofile",
+    );
+
+    expect(getProfileUser).not.toHaveBeenCalled();
+    expect(getListingsByOwner).not.toHaveBeenCalled();
+  });
+
+  it("renders the signed-in user's profile and all owned listing statuses", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: ownerId,
+        email: "owner@example.com",
+        name: "Owner Name",
+      },
+      expires: "2026-06-01T00:00:00.000Z",
+    });
+    vi.mocked(getProfileUser).mockResolvedValue({
+      id: ownerId,
+      email: "owner@example.com",
+      name: "Owner Name",
+      contactEmail: "renter@example.com",
+      contactPhone: "320-555-1212",
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+    vi.mocked(getListingsByOwner).mockResolvedValue(ownedListings);
+
+    const page = await ProfilePage();
+
+    expect(getProfileUser).toHaveBeenCalledWith(ownerId);
+    expect(getListingsByOwner).toHaveBeenCalledWith(ownerId);
+    expect(includesText(page, "Owner Name")).toBe(true);
+    expect(includesText(page, "owner@example.com")).toBe(true);
+    expect(includesText(page, "Account basics")).toBe(true);
+    expect(includesText(page, "Joined May 1, 2026")).toBe(true);
+    expect(includesText(page, "Active room near SCSU")).toBe(true);
+    expect(includesText(page, "Archived studio")).toBe(true);
+    expect(includesText(page, "ARCHIVED")).toBe(true);
+    expect(hasHref(page, "/listings/507f1f77bcf86cd799439011/edit")).toBe(true);
+  });
+});

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,0 +1,157 @@
+import type { Listing } from "@prisma/client";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { ListingArchiveButton } from "@/features/listings/components/listing-archive-button";
+import { getListingsByOwner } from "@/features/listings/queries";
+import { ProfileAccountForm } from "@/features/profile/components/profile-account-form";
+import { getProfileUser } from "@/features/profile/queries";
+import { auth } from "@/server/auth/auth";
+
+export const dynamic = "force-dynamic";
+
+function formatDate(date: Date) {
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function renderProfileListingRow(listing: Listing) {
+  const isArchived = listing.status === "ARCHIVED";
+
+  return (
+    <article
+      key={listing.id}
+      className="grid gap-4 rounded-md border border-zinc-200 p-4 md:grid-cols-[1fr_auto] md:items-center"
+    >
+      <div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-md border border-zinc-200 px-2 py-1 text-xs font-medium text-zinc-700">
+            {listing.type}
+          </span>
+          <span className="rounded-md bg-zinc-100 px-2 py-1 text-xs font-medium text-zinc-700">
+            {listing.status}
+          </span>
+        </div>
+        <h2 className="mt-3 text-lg font-semibold text-zinc-950">
+          {listing.title}
+        </h2>
+        <p className="mt-1 text-sm text-zinc-600">
+          ${listing.rent}/month · Updated {formatDate(listing.updatedAt)}
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Link
+          href={`/listings/${listing.id}`}
+          className="rounded-md border border-zinc-300 px-3 py-2 text-sm font-medium text-zinc-950 hover:bg-zinc-100"
+        >
+          View
+        </Link>
+        <Link
+          href={`/listings/${listing.id}/edit`}
+          className="rounded-md bg-zinc-950 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+        >
+          Edit
+        </Link>
+        {!isArchived ? <ListingArchiveButton listingId={listing.id} /> : null}
+      </div>
+    </article>
+  );
+}
+
+export default async function ProfilePage() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/login?callbackUrl=%2Fprofile");
+  }
+
+  const [profileUser, listings] = await Promise.all([
+    getProfileUser(session.user.id),
+    getListingsByOwner(session.user.id),
+  ]);
+  const displayName = profileUser?.name ?? session.user.name ?? "Renter";
+  const email = profileUser?.email ?? session.user.email;
+
+  return (
+    <main className="mx-auto w-full max-w-6xl px-6 py-10">
+      <section className="grid gap-6 border-b border-zinc-200 pb-8 md:grid-cols-[1fr_auto] md:items-end">
+        <div>
+          <p className="text-sm font-medium uppercase text-emerald-700">
+            Profile
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold text-zinc-950">
+            {displayName}
+          </h1>
+          {email ? <p className="mt-2 text-zinc-600">{email}</p> : null}
+          {profileUser?.createdAt ? (
+            <p className="mt-1 text-sm text-zinc-500">
+              {`Joined ${formatDate(profileUser.createdAt)}`}
+            </p>
+          ) : null}
+        </div>
+        <Link
+          href="/listings/new"
+          className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+        >
+          Post listing
+        </Link>
+      </section>
+
+      {profileUser ? (
+        <section className="mt-8">
+          <div>
+            <h2 className="text-2xl font-semibold text-zinc-950">
+              Account basics
+            </h2>
+            <p className="mt-1 text-sm text-zinc-600">
+              Keep your display name and default contact details ready for new
+              listings.
+            </p>
+          </div>
+          <ProfileAccountForm user={profileUser} />
+        </section>
+      ) : null}
+
+      <section className="mt-8">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h2 className="text-2xl font-semibold text-zinc-950">
+              Your listings
+            </h2>
+            <p className="mt-1 text-sm text-zinc-600">
+              Manage active, draft, rented, and archived posts from one place.
+            </p>
+          </div>
+          <p className="text-sm font-medium text-zinc-500">
+            {listings.length} total
+          </p>
+        </div>
+
+        {listings.length === 0 ? (
+          <div className="mt-6 rounded-md border border-dashed border-zinc-300 px-6 py-10 text-center">
+            <h3 className="text-lg font-semibold text-zinc-950">
+              No listings yet
+            </h3>
+            <p className="mx-auto mt-2 max-w-md text-sm text-zinc-600">
+              Post your first apartment, room, or roommate lead so renters can
+              find it near campus.
+            </p>
+            <Link
+              href="/listings/new"
+              className="mt-5 inline-flex rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+            >
+              Post your first listing
+            </Link>
+          </div>
+        ) : (
+          <div className="mt-6 grid gap-3">
+            {listings.map(renderProfileListingRow)}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/features/listings/components/listing-create-form.tsx
+++ b/apps/web/src/features/listings/components/listing-create-form.tsx
@@ -33,6 +33,7 @@ type ListingFormValue = {
   contactPhone?: string | null;
   bedrooms: number | null;
   bathrooms: number | null;
+  petPolicy: ListingCreateInput["petPolicy"];
   amenities: string[];
   imageUrls: string[];
 };
@@ -41,6 +42,7 @@ type ListingCreateFormProps = {
   listing?: ListingFormValue;
   mode?: "create" | "edit";
   defaultContactEmail?: string | null;
+  defaultContactPhone?: string | null;
 };
 
 const MAX_IMAGES = 5;
@@ -66,6 +68,7 @@ export function ListingCreateForm({
   listing,
   mode = "create",
   defaultContactEmail,
+  defaultContactPhone,
 }: ListingCreateFormProps) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -328,7 +331,7 @@ export function ListingCreateForm({
             id="contactPhone"
             name="contactPhone"
             type="tel"
-            defaultValue={listing?.contactPhone ?? ""}
+            defaultValue={listing?.contactPhone ?? defaultContactPhone ?? ""}
             className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
             placeholder="320-555-1212"
           />
@@ -365,6 +368,24 @@ export function ListingCreateForm({
             className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
           />
         </div>
+      </div>
+
+      <div className="grid gap-2">
+        <label htmlFor="petPolicy" className="text-sm font-medium text-zinc-800">
+          Pet policy
+        </label>
+        <select
+          id="petPolicy"
+          name="petPolicy"
+          defaultValue={listing?.petPolicy ?? "UNKNOWN"}
+          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+        >
+          <option value="UNKNOWN">Not specified</option>
+          <option value="PETS_ALLOWED">Pets allowed</option>
+          <option value="CATS_ONLY">Cats only</option>
+          <option value="DOGS_ONLY">Dogs only</option>
+          <option value="NO_PETS">No pets</option>
+        </select>
       </div>
 
       <label className="flex items-center gap-3 text-sm font-medium text-zinc-800">

--- a/apps/web/src/features/listings/components/listing-filter-form.test.tsx
+++ b/apps/web/src/features/listings/components/listing-filter-form.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { ListingFilterForm } from "@/features/listings/components/listing-filter-form";
+
+function hasInputDefault(node: unknown, name: string, defaultValue: string): boolean {
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const element = node as {
+    props?: {
+      children?: unknown;
+      defaultValue?: unknown;
+      name?: unknown;
+    };
+  };
+
+  if (element.props?.name === name && element.props.defaultValue === defaultValue) {
+    return true;
+  }
+
+  const children = element.props?.children;
+
+  if (Array.isArray(children)) {
+    return children.some((child) => hasInputDefault(child, name, defaultValue));
+  }
+
+  return hasInputDefault(children, name, defaultValue);
+}
+
+describe("ListingFilterForm", () => {
+  it("renders current listing discovery filters", () => {
+    const form = ListingFilterForm({
+      filters: {
+        type: "ROOM",
+        rentMin: 700,
+        rentMax: 1200,
+        bedroomsMin: 1,
+        bathroomsMin: 1.5,
+        availableBy: "2026-08-01",
+        petPolicy: "PETS_ALLOWED",
+      },
+    });
+
+    expect(hasInputDefault(form, "rentMin", "700")).toBe(true);
+    expect(hasInputDefault(form, "rentMax", "1200")).toBe(true);
+    expect(hasInputDefault(form, "bedroomsMin", "1")).toBe(true);
+    expect(hasInputDefault(form, "bathroomsMin", "1.5")).toBe(true);
+    expect(hasInputDefault(form, "availableBy", "2026-08-01")).toBe(true);
+  });
+});

--- a/apps/web/src/features/listings/components/listing-filter-form.tsx
+++ b/apps/web/src/features/listings/components/listing-filter-form.tsx
@@ -1,0 +1,164 @@
+import Link from "next/link";
+
+import { type ListingQueryInput } from "@/features/listings/schemas";
+
+type ListingFilterFormProps = {
+  filters: ListingQueryInput;
+};
+
+function value(value: string | number | undefined) {
+  return value === undefined ? "" : String(value);
+}
+
+export function ListingFilterForm({ filters }: ListingFilterFormProps) {
+  return (
+    <form
+      action="/listings"
+      className="mb-8 grid gap-4 rounded-md border border-zinc-200 p-4"
+    >
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid gap-2">
+          <label htmlFor="rentMin" className="text-sm font-medium text-zinc-800">
+            Min price
+          </label>
+          <input
+            id="rentMin"
+            name="rentMin"
+            type="number"
+            min="0"
+            step="1"
+            defaultValue={value(filters.rentMin)}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            placeholder="700"
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <label htmlFor="rentMax" className="text-sm font-medium text-zinc-800">
+            Max price
+          </label>
+          <input
+            id="rentMax"
+            name="rentMax"
+            type="number"
+            min="0"
+            step="1"
+            defaultValue={value(filters.rentMax)}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            placeholder="1200"
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <label htmlFor="type" className="text-sm font-medium text-zinc-800">
+            Home type
+          </label>
+          <select
+            id="type"
+            name="type"
+            defaultValue={filters.type ?? ""}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          >
+            <option value="">Any type</option>
+            <option value="APARTMENT">Apartment</option>
+            <option value="ROOM">Room</option>
+            <option value="ROOMMATE">Roommate lead</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <div className="grid gap-2">
+          <label
+            htmlFor="bedroomsMin"
+            className="text-sm font-medium text-zinc-800"
+          >
+            Beds
+          </label>
+          <input
+            id="bedroomsMin"
+            name="bedroomsMin"
+            type="number"
+            min="0"
+            step="1"
+            defaultValue={value(filters.bedroomsMin)}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            placeholder="1"
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <label
+            htmlFor="bathroomsMin"
+            className="text-sm font-medium text-zinc-800"
+          >
+            Baths
+          </label>
+          <input
+            id="bathroomsMin"
+            name="bathroomsMin"
+            type="number"
+            min="0"
+            step="0.5"
+            defaultValue={value(filters.bathroomsMin)}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            placeholder="1"
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <label
+            htmlFor="availableBy"
+            className="text-sm font-medium text-zinc-800"
+          >
+            Move-in by
+          </label>
+          <input
+            id="availableBy"
+            name="availableBy"
+            type="date"
+            defaultValue={filters.availableBy ?? ""}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <label
+            htmlFor="petPolicy"
+            className="text-sm font-medium text-zinc-800"
+          >
+            Pet policy
+          </label>
+          <select
+            id="petPolicy"
+            name="petPolicy"
+            defaultValue={filters.petPolicy ?? ""}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          >
+            <option value="">Any policy</option>
+            <option value="PETS_ALLOWED">Pets allowed</option>
+            <option value="CATS_ONLY">Cats only</option>
+            <option value="DOGS_ONLY">Dogs only</option>
+            <option value="NO_PETS">No pets</option>
+            <option value="UNKNOWN">Not specified</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="submit"
+          className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+        >
+          Apply filters
+        </button>
+        <Link
+          href="/listings"
+          className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-950 hover:bg-zinc-100"
+        >
+          Clear
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/features/listings/form-payload.test.ts
+++ b/apps/web/src/features/listings/form-payload.test.ts
@@ -19,6 +19,7 @@ describe("createListingPayloadFromFormData", () => {
     formData.set("contactPhone", " 320-555-1212 ");
     formData.set("bedrooms", "2");
     formData.set("bathrooms", "1.5");
+    formData.set("petPolicy", "PETS_ALLOWED");
     formData.set("amenities", "Laundry, Parking");
     formData.append("imageUrls", "data:image/png;base64,abc123");
     formData.append("imageUrls", "data:image/jpeg;base64,def456");
@@ -39,6 +40,7 @@ describe("createListingPayloadFromFormData", () => {
       contactPhone: "320-555-1212",
       bedrooms: 2,
       bathrooms: 1.5,
+      petPolicy: "PETS_ALLOWED",
       amenities: ["Laundry", "Parking"],
       imageUrls: ["data:image/png;base64,abc123", "data:image/jpeg;base64,def456"],
     });

--- a/apps/web/src/features/listings/form-payload.ts
+++ b/apps/web/src/features/listings/form-payload.ts
@@ -58,6 +58,7 @@ export function createListingPayloadFromFormData(
     contactPhone: nullableStringValue(formData, "contactPhone"),
     bedrooms: nullableNumberValue(formData, "bedrooms"),
     bathrooms: nullableNumberValue(formData, "bathrooms"),
+    petPolicy: stringValue(formData, "petPolicy") as ListingCreateInput["petPolicy"],
     amenities: textareaListValue(formData, "amenities"),
     imageUrls: repeatedStringValue(formData, "imageUrls"),
   };

--- a/apps/web/src/features/listings/queries.test.ts
+++ b/apps/web/src/features/listings/queries.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getActiveListings, getListingsByOwner } from "@/features/listings/queries";
+import { prisma } from "@/server/db/prisma";
+
+vi.mock("@/server/db/prisma", () => ({
+  prisma: {
+    listing: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+describe("listing queries", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.listing.findMany).mockReset();
+    process.env.DATABASE_URL = "mongodb://example.test/allapartments";
+  });
+
+  it("keeps public listing reads limited to active listings", async () => {
+    vi.mocked(prisma.listing.findMany).mockResolvedValue([]);
+
+    await getActiveListings({ type: "ROOM" });
+
+    expect(prisma.listing.findMany).toHaveBeenCalledWith({
+      where: {
+        status: "ACTIVE",
+        type: "ROOM",
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+  });
+
+  it("applies indexed discovery filters for public listing reads", async () => {
+    vi.mocked(prisma.listing.findMany).mockResolvedValue([]);
+
+    await getActiveListings({
+      type: "ROOM",
+      rentMin: 700,
+      rentMax: 1200,
+      bedroomsMin: 1,
+      bathroomsMin: 1.5,
+      availableBy: "2026-08-01",
+      petPolicy: "PETS_ALLOWED",
+    });
+
+    expect(prisma.listing.findMany).toHaveBeenCalledWith({
+      where: {
+        status: "ACTIVE",
+        type: "ROOM",
+        rent: {
+          gte: 700,
+          lte: 1200,
+        },
+        bedrooms: {
+          gte: 1,
+        },
+        bathrooms: {
+          gte: 1.5,
+        },
+        petPolicy: "PETS_ALLOWED",
+        OR: [
+          {
+            availableFrom: null,
+          },
+          {
+            availableFrom: {
+              lte: new Date("2026-08-01T00:00:00.000Z"),
+            },
+          },
+        ],
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+  });
+
+  it("returns all statuses for owner profile listing management", async () => {
+    vi.mocked(prisma.listing.findMany).mockResolvedValue([]);
+
+    await getListingsByOwner("507f1f77bcf86cd799439099");
+
+    expect(prisma.listing.findMany).toHaveBeenCalledWith({
+      where: {
+        ownerId: "507f1f77bcf86cd799439099",
+      },
+      orderBy: {
+        updatedAt: "desc",
+      },
+    });
+  });
+});

--- a/apps/web/src/features/listings/queries.ts
+++ b/apps/web/src/features/listings/queries.ts
@@ -1,23 +1,86 @@
-import { ListingStatus, ListingType } from "@prisma/client";
+import { ListingStatus, type Prisma } from "@prisma/client";
 
+import { type ListingQueryInput } from "@/features/listings/schemas";
 import { prisma } from "@/server/db/prisma";
 
 function hasDatabaseUrl() {
   return Boolean(process.env.DATABASE_URL);
 }
 
-export async function getActiveListings(type?: ListingType) {
+function availableByDate(value: string) {
+  return new Date(`${value}T00:00:00.000Z`);
+}
+
+function toActiveListingWhere(filters: ListingQueryInput = {}) {
+  const where: Prisma.ListingWhereInput = {
+    status: ListingStatus.ACTIVE,
+    ...(filters.type ? { type: filters.type } : {}),
+    ...(filters.rentMin !== undefined || filters.rentMax !== undefined
+      ? {
+          rent: {
+            ...(filters.rentMin !== undefined ? { gte: filters.rentMin } : {}),
+            ...(filters.rentMax !== undefined ? { lte: filters.rentMax } : {}),
+          },
+        }
+      : {}),
+    ...(filters.bedroomsMin !== undefined
+      ? {
+          bedrooms: {
+            gte: filters.bedroomsMin,
+          },
+        }
+      : {}),
+    ...(filters.bathroomsMin !== undefined
+      ? {
+          bathrooms: {
+            gte: filters.bathroomsMin,
+          },
+        }
+      : {}),
+    ...(filters.petPolicy ? { petPolicy: filters.petPolicy } : {}),
+    ...(filters.availableBy
+      ? {
+          OR: [
+            {
+              availableFrom: null,
+            },
+            {
+              availableFrom: {
+                lte: availableByDate(filters.availableBy),
+              },
+            },
+          ],
+        }
+      : {}),
+  };
+
+  return where;
+}
+
+export async function getActiveListings(filters: ListingQueryInput = {}) {
+  if (!hasDatabaseUrl()) {
+    return [];
+  }
+
+  return prisma.listing.findMany({
+    where: toActiveListingWhere(filters),
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+}
+
+export async function getListingsByOwner(ownerId: string) {
   if (!hasDatabaseUrl()) {
     return [];
   }
 
   return prisma.listing.findMany({
     where: {
-      status: ListingStatus.ACTIVE,
-      ...(type ? { type } : {}),
+      ownerId,
     },
     orderBy: {
-      createdAt: "desc",
+      updatedAt: "desc",
     },
   });
 }

--- a/apps/web/src/features/listings/schemas.test.ts
+++ b/apps/web/src/features/listings/schemas.test.ts
@@ -26,6 +26,7 @@ describe("listing API schemas", () => {
       contactPhone: null,
       bedrooms: 1,
       bathrooms: 1,
+      petPolicy: "PETS_ALLOWED",
       amenities: ["Laundry"],
       imageUrls: [],
       ownerId: null,
@@ -42,6 +43,38 @@ describe("listing API schemas", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("accepts structured discovery filters", () => {
+    const parsed = listingQuerySchema.safeParse({
+      type: "ROOM",
+      rentMin: "700",
+      rentMax: "1200",
+      bedroomsMin: "1",
+      bathroomsMin: "1.5",
+      availableBy: "2026-08-01",
+      petPolicy: "PETS_ALLOWED",
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.success ? parsed.data : null).toEqual({
+      type: "ROOM",
+      rentMin: 700,
+      rentMax: 1200,
+      bedroomsMin: 1,
+      bathroomsMin: 1.5,
+      availableBy: "2026-08-01",
+      petPolicy: "PETS_ALLOWED",
+    });
+  });
+
+  it("rejects inverted rent filters", () => {
+    const parsed = listingQuerySchema.safeParse({
+      rentMin: "1400",
+      rentMax: "900",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
   it("requires a non-empty listing id path parameter", () => {
     const parsed = listingParamsSchema.safeParse({ id: "" });
 
@@ -54,6 +87,7 @@ describe("listing API schemas", () => {
       type: "ROOM",
       description: "Private room near campus.",
       rent: 850,
+      petPolicy: "PETS_ALLOWED",
       imageUrls: ["data:image/png;base64,abc123"],
     });
 

--- a/apps/web/src/features/listings/schemas.ts
+++ b/apps/web/src/features/listings/schemas.ts
@@ -5,6 +5,13 @@ extendZodWithOpenApi(z);
 
 export const listingTypeSchema = z.enum(["APARTMENT", "ROOM", "ROOMMATE"]);
 export const listingStatusSchema = z.enum(["DRAFT", "ACTIVE", "RENTED", "ARCHIVED"]);
+export const petPolicySchema = z.enum([
+  "UNKNOWN",
+  "NO_PETS",
+  "CATS_ONLY",
+  "DOGS_ONLY",
+  "PETS_ALLOWED",
+]);
 const imageUrlSchema = z
   .string()
   .url()
@@ -23,9 +30,35 @@ const nullablePhoneSchema = z
   .max(30)
   .nullable();
 
-export const listingQuerySchema = z.object({
-  type: listingTypeSchema.optional(),
-});
+const optionalQueryNumberSchema = z.preprocess(
+  (value) => (value === "" || value === null ? undefined : value),
+  z.coerce.number().nonnegative().optional(),
+);
+
+export const listingQuerySchema = z
+  .object({
+    type: listingTypeSchema.optional(),
+    rentMin: optionalQueryNumberSchema,
+    rentMax: optionalQueryNumberSchema,
+    bedroomsMin: optionalQueryNumberSchema.pipe(z.number().int().optional()),
+    bathroomsMin: optionalQueryNumberSchema,
+    availableBy: z
+      .preprocess(
+        (value) => (value === "" || value === null ? undefined : value),
+        z.string().date().optional(),
+      ),
+    petPolicy: petPolicySchema.optional(),
+  })
+  .refine(
+    (value) =>
+      value.rentMin === undefined ||
+      value.rentMax === undefined ||
+      value.rentMin <= value.rentMax,
+    {
+      message: "Minimum rent must be less than or equal to maximum rent.",
+      path: ["rentMax"],
+    },
+  );
 
 export const listingParamsSchema = z.object({
   id: z.string().trim().min(1, "Listing id is required."),
@@ -48,6 +81,7 @@ export const listingResponseSchema = z.object({
   contactPhone: z.string().nullable(),
   bedrooms: z.number().int().nonnegative().nullable(),
   bathrooms: z.number().nonnegative().nullable(),
+  petPolicy: petPolicySchema,
   amenities: z.array(z.string()),
   imageUrls: z.array(imageUrlSchema),
   ownerId: z.string().nullable(),
@@ -79,6 +113,7 @@ export const listingCreateBodySchema = z.object({
   contactPhone: nullablePhoneSchema.default(null),
   bedrooms: z.number().int().nonnegative().nullable().default(null),
   bathrooms: z.number().nonnegative().nullable().default(null),
+  petPolicy: petPolicySchema.default("UNKNOWN"),
   amenities: z.array(z.string().trim().min(1)).default([]),
   imageUrls: z
     .array(imageUrlSchema)
@@ -103,6 +138,7 @@ export const listingUpdateBodySchema = z
     contactPhone: z.string().trim().min(7).max(30).nullable().optional(),
     bedrooms: z.number().int().nonnegative().nullable().optional(),
     bathrooms: z.number().nonnegative().nullable().optional(),
+    petPolicy: petPolicySchema.optional(),
     amenities: z.array(z.string().trim().min(1)).optional(),
     imageUrls: z
       .array(imageUrlSchema)
@@ -114,6 +150,7 @@ export const listingUpdateBodySchema = z
   });
 
 export type ListingApiResponse = z.infer<typeof listingResponseSchema>;
+export type ListingQueryInput = z.infer<typeof listingQuerySchema>;
 export type ListingCreateInput = z.infer<typeof listingCreateBodySchema>;
 export type ListingUpdateInput = z.infer<typeof listingUpdateBodySchema>;
 
@@ -134,6 +171,7 @@ type ListingForApi = {
   contactPhone?: string | null;
   bedrooms: number | null;
   bathrooms: number | null;
+  petPolicy: "UNKNOWN" | "NO_PETS" | "CATS_ONLY" | "DOGS_ONLY" | "PETS_ALLOWED";
   amenities: string[];
   imageUrls: string[];
   ownerId: string | null;

--- a/apps/web/src/features/profile/components/profile-account-form.test.tsx
+++ b/apps/web/src/features/profile/components/profile-account-form.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { ProfileAccountFields } from "@/features/profile/components/profile-account-form";
+
+function hasInputDefault(node: unknown, name: string, defaultValue: string): boolean {
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const element = node as {
+    props?: {
+      children?: unknown;
+      defaultValue?: unknown;
+      name?: unknown;
+    };
+  };
+
+  if (element.props?.name === name && element.props.defaultValue === defaultValue) {
+    return true;
+  }
+
+  const children = element.props?.children;
+
+  if (Array.isArray(children)) {
+    return children.some((child) => hasInputDefault(child, name, defaultValue));
+  }
+
+  return hasInputDefault(children, name, defaultValue);
+}
+
+describe("ProfileAccountFields", () => {
+  it("prefills editable account basics and contact defaults", () => {
+    const form = ProfileAccountFields({
+      user: {
+        id: "507f1f77bcf86cd799439099",
+        email: "owner@example.com",
+        name: "Kushal Singh",
+        contactEmail: "renter@example.com",
+        contactPhone: "320-555-1212",
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+    });
+
+    expect(hasInputDefault(form, "name", "Kushal Singh")).toBe(true);
+    expect(hasInputDefault(form, "contactEmail", "renter@example.com")).toBe(true);
+    expect(hasInputDefault(form, "contactPhone", "320-555-1212")).toBe(true);
+  });
+});

--- a/apps/web/src/features/profile/components/profile-account-form.tsx
+++ b/apps/web/src/features/profile/components/profile-account-form.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+
+import type { ProfileUser } from "@/features/profile/queries";
+
+type ApiErrorBody = {
+  error?: {
+    message?: string;
+  };
+};
+
+async function readErrorMessage(response: Response) {
+  const body = (await response.json().catch(() => null)) as ApiErrorBody | null;
+  return body?.error?.message ?? "Could not update your profile. Please try again.";
+}
+
+function nullableStringValue(formData: FormData, key: string) {
+  const value = String(formData.get(key) ?? "").trim();
+  return value.length > 0 ? value : null;
+}
+
+export function ProfileAccountForm({ user }: { user: ProfileUser }) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setNotice(null);
+    setIsSubmitting(true);
+
+    const formData = new FormData(event.currentTarget);
+
+    try {
+      const response = await fetch("/api/profile", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: nullableStringValue(formData, "name"),
+          contactEmail: nullableStringValue(formData, "contactEmail"),
+          contactPhone: nullableStringValue(formData, "contactPhone"),
+        }),
+      });
+
+      if (!response.ok) {
+        setError(await readErrorMessage(response));
+        return;
+      }
+
+      setNotice("Profile updated.");
+      router.refresh();
+    } catch {
+      setError("Could not update your profile. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mt-4 grid gap-4 rounded-md border border-zinc-200 p-4"
+    >
+      {error ? (
+        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+      {notice ? (
+        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+          {notice}
+        </div>
+      ) : null}
+
+      <ProfileAccountFields user={user} />
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="justify-self-start rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+      >
+        {isSubmitting ? "Saving..." : "Save profile"}
+      </button>
+    </form>
+  );
+}
+
+export function ProfileAccountFields({ user }: { user: ProfileUser }) {
+  return (
+    <>
+      <div className="grid gap-2">
+        <label htmlFor="name" className="text-sm font-medium text-zinc-800">
+          Display name
+        </label>
+        <input
+          id="name"
+          name="name"
+          required
+          defaultValue={user.name ?? ""}
+          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          placeholder="Kushal Singh"
+        />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-2">
+          <label
+            htmlFor="contactEmail"
+            className="text-sm font-medium text-zinc-800"
+          >
+            Default contact email
+          </label>
+          <input
+            id="contactEmail"
+            name="contactEmail"
+            type="email"
+            defaultValue={user.contactEmail ?? ""}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            placeholder={user.email}
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <label
+            htmlFor="contactPhone"
+            className="text-sm font-medium text-zinc-800"
+          >
+            Default contact phone
+          </label>
+          <input
+            id="contactPhone"
+            name="contactPhone"
+            type="tel"
+            defaultValue={user.contactPhone ?? ""}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            placeholder="320-555-1212"
+          />
+        </div>
+      </div>
+
+    </>
+  );
+}

--- a/apps/web/src/features/profile/mutations.test.ts
+++ b/apps/web/src/features/profile/mutations.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { updateProfileUser } from "@/features/profile/mutations";
+import { prisma } from "@/server/db/prisma";
+
+vi.mock("@/server/db/prisma", () => ({
+  prisma: {
+    user: {
+      update: vi.fn(),
+    },
+  },
+}));
+
+describe("profile mutations", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.user.update).mockReset();
+    process.env.DATABASE_URL = "mongodb://example.test/allapartments";
+  });
+
+  it("updates safe account basics and contact defaults", async () => {
+    vi.mocked(prisma.user.update).mockResolvedValue({
+      id: "507f1f77bcf86cd799439099",
+      email: "owner@example.com",
+      name: "Kushal Singh",
+      contactEmail: "renter@example.com",
+      contactPhone: "320-555-1212",
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+
+    const profileUser = await updateProfileUser("507f1f77bcf86cd799439099", {
+      name: "Kushal Singh",
+      contactEmail: "renter@example.com",
+      contactPhone: "320-555-1212",
+    });
+
+    expect(profileUser).toEqual({
+      id: "507f1f77bcf86cd799439099",
+      email: "owner@example.com",
+      name: "Kushal Singh",
+      contactEmail: "renter@example.com",
+      contactPhone: "320-555-1212",
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: {
+        id: "507f1f77bcf86cd799439099",
+      },
+      data: {
+        name: "Kushal Singh",
+        contactEmail: "renter@example.com",
+        contactPhone: "320-555-1212",
+      },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        contactEmail: true,
+        contactPhone: true,
+        createdAt: true,
+      },
+    });
+  });
+});

--- a/apps/web/src/features/profile/mutations.ts
+++ b/apps/web/src/features/profile/mutations.ts
@@ -1,0 +1,27 @@
+import { type ProfileUpdateInput } from "@/features/profile/schemas";
+import { prisma } from "@/server/db/prisma";
+
+function hasDatabaseUrl() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+export async function updateProfileUser(userId: string, input: ProfileUpdateInput) {
+  if (!hasDatabaseUrl()) {
+    return null;
+  }
+
+  return prisma.user.update({
+    where: {
+      id: userId,
+    },
+    data: input,
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      contactEmail: true,
+      contactPhone: true,
+      createdAt: true,
+    },
+  });
+}

--- a/apps/web/src/features/profile/queries.test.ts
+++ b/apps/web/src/features/profile/queries.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getProfileUser } from "@/features/profile/queries";
+import { prisma } from "@/server/db/prisma";
+
+vi.mock("@/server/db/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+describe("profile queries", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.user.findUnique).mockReset();
+    process.env.DATABASE_URL = "mongodb://example.test/allapartments";
+  });
+
+  it("loads safe profile account fields for the signed-in user", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "507f1f77bcf86cd799439099",
+      email: "owner@example.com",
+      name: "Owner Name",
+      contactEmail: "renter@example.com",
+      contactPhone: "320-555-1212",
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+
+    const profileUser = await getProfileUser("507f1f77bcf86cd799439099");
+
+    expect(profileUser).toEqual({
+      id: "507f1f77bcf86cd799439099",
+      email: "owner@example.com",
+      name: "Owner Name",
+      contactEmail: "renter@example.com",
+      contactPhone: "320-555-1212",
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: {
+        id: "507f1f77bcf86cd799439099",
+      },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        contactEmail: true,
+        contactPhone: true,
+        createdAt: true,
+      },
+    });
+  });
+});

--- a/apps/web/src/features/profile/queries.ts
+++ b/apps/web/src/features/profile/queries.ts
@@ -1,0 +1,34 @@
+import { prisma } from "@/server/db/prisma";
+
+function hasDatabaseUrl() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+export type ProfileUser = {
+  id: string;
+  email: string;
+  name: string | null;
+  contactEmail: string | null;
+  contactPhone: string | null;
+  createdAt: Date;
+};
+
+export async function getProfileUser(userId: string): Promise<ProfileUser | null> {
+  if (!hasDatabaseUrl()) {
+    return null;
+  }
+
+  return prisma.user.findUnique({
+    where: {
+      id: userId,
+    },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      contactEmail: true,
+      contactPhone: true,
+      createdAt: true,
+    },
+  });
+}

--- a/apps/web/src/features/profile/schemas.test.ts
+++ b/apps/web/src/features/profile/schemas.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { profileUpdateBodySchema } from "@/features/profile/schemas";
+
+describe("profile schemas", () => {
+  it("accepts display name and optional contact defaults", () => {
+    const result = profileUpdateBodySchema.safeParse({
+      name: " Kushal Singh ",
+      contactEmail: " renter@example.com ",
+      contactPhone: " 320-555-1212 ",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.success ? result.data : null).toEqual({
+      name: "Kushal Singh",
+      contactEmail: "renter@example.com",
+      contactPhone: "320-555-1212",
+    });
+  });
+
+  it("rejects empty profile updates", () => {
+    const result = profileUpdateBodySchema.safeParse({});
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/features/profile/schemas.ts
+++ b/apps/web/src/features/profile/schemas.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+const optionalContactEmailSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .email()
+  .nullable()
+  .optional();
+
+const optionalContactPhoneSchema = z
+  .string()
+  .trim()
+  .min(7)
+  .max(30)
+  .nullable()
+  .optional();
+
+export const profileUpdateBodySchema = z
+  .object({
+    name: z.string().trim().min(2, "Name must be at least 2 characters.").max(80).optional(),
+    contactEmail: optionalContactEmailSchema,
+    contactPhone: optionalContactPhoneSchema,
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one profile field is required.",
+  });
+
+export type ProfileUpdateInput = z.infer<typeof profileUpdateBodySchema>;


### PR DESCRIPTION
## Summary

- Add an authenticated `/profile` dashboard with account identity, editable account/contact defaults, and owned listing management.
- Add signed-in profile navigation and protect profile updates behind the active session.
- Add listing filters for price, beds, baths, home type, move-in date, and pet policy, backed by schema validation and optimized Prisma indexes.
- Keep renter preferences out of profile; listing search filters now cover renter-specific apartment matching.

## Validation

- `./scripts/security-scan.sh`
- `npm test` in `apps/web`
- `npm run lint` in `apps/web`

## Notes

- `npm run build` was not rerun after the final filter/profile cleanup because the local sandbox requires elevated network/runtime access for the Next/Turbopack build step and that escalation was not approved in the prior run.