### PR TITLE
Fix listing filter query handling

### DIFF
--- a/apps/web/src/app/api/listings/route.test.ts
+++ b/apps/web/src/app/api/listings/route.test.ts
@@ -93,6 +93,67 @@ describe("GET /api/listings", () => {
     });
   });
 
+  it("accepts min and max aliases for rent filters", async () => {
+    vi.mocked(getActiveListings).mockResolvedValue([listing]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/listings?min=1100&max=1600"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getActiveListings).toHaveBeenCalledWith({
+      type: undefined,
+      rentMin: 1100,
+      rentMax: 1600,
+      bedroomsMin: undefined,
+      bathroomsMin: undefined,
+      availableBy: undefined,
+      petPolicy: undefined,
+    });
+  });
+
+  it("ignores empty trailing filter params instead of dropping valid filters", async () => {
+    vi.mocked(getActiveListings).mockResolvedValue([listing]);
+
+    const response = await GET(
+      new Request(
+        "http://localhost:3000/api/listings?rentMin=1000&rentMax=1600&type=&bedroomsMin=&bathroomsMin=&availableBy=&petPolicy=",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getActiveListings).toHaveBeenCalledWith({
+      type: undefined,
+      rentMin: 1000,
+      rentMax: 1600,
+      bedroomsMin: undefined,
+      bathroomsMin: undefined,
+      availableBy: undefined,
+      petPolicy: undefined,
+    });
+  });
+
+  it("uses a single non-empty filter when the rest are empty", async () => {
+    vi.mocked(getActiveListings).mockResolvedValue([listing]);
+
+    const response = await GET(
+      new Request(
+        "http://localhost:3000/api/listings?rentMin=&rentMax=&type=ROOM&bedroomsMin=&bathroomsMin=&availableBy=&petPolicy=",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getActiveListings).toHaveBeenCalledWith({
+      type: "ROOM",
+      rentMin: undefined,
+      rentMax: undefined,
+      bedroomsMin: undefined,
+      bathroomsMin: undefined,
+      availableBy: undefined,
+      petPolicy: undefined,
+    });
+  });
+
   it("returns a validation error for unsupported filters", async () => {
     const response = await GET(
       new Request("http://localhost:3000/api/listings?type=HOUSE"),

--- a/apps/web/src/app/api/listings/route.ts
+++ b/apps/web/src/app/api/listings/route.ts
@@ -1,5 +1,6 @@
 import {
   listingCreateBodySchema,
+  listingQueryInputFromParams,
   listingQuerySchema,
   serializeListing,
 } from "@/features/listings/schemas";
@@ -15,15 +16,7 @@ export async function GET(request: Request) {
   return withApiErrorHandling(async () => {
     const url = new URL(request.url);
     const query = throwIfInvalid(
-      listingQuerySchema.safeParse({
-        type: url.searchParams.get("type") ?? undefined,
-        rentMin: url.searchParams.get("rentMin") ?? undefined,
-        rentMax: url.searchParams.get("rentMax") ?? undefined,
-        bedroomsMin: url.searchParams.get("bedroomsMin") ?? undefined,
-        bathroomsMin: url.searchParams.get("bathroomsMin") ?? undefined,
-        availableBy: url.searchParams.get("availableBy") ?? undefined,
-        petPolicy: url.searchParams.get("petPolicy") ?? undefined,
-      }),
+      listingQuerySchema.safeParse(listingQueryInputFromParams(url.searchParams)),
     );
 
     const listings = await getActiveListings(query);

--- a/apps/web/src/app/listings/page.test.tsx
+++ b/apps/web/src/app/listings/page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ListingsPage from "@/app/listings/page";
 import { getActiveListings } from "@/features/listings/queries";
@@ -7,7 +7,26 @@ vi.mock("@/features/listings/queries", () => ({
   getActiveListings: vi.fn(),
 }));
 
+function expandNode(node: unknown): unknown {
+  if (!node || typeof node !== "object") {
+    return node;
+  }
+
+  const element = node as {
+    props?: unknown;
+    type?: unknown;
+  };
+
+  if (typeof element.type === "function") {
+    return element.type(element.props);
+  }
+
+  return node;
+}
+
 function includesText(node: unknown, text: string): boolean {
+  node = expandNode(node);
+
   if (typeof node === "string" || typeof node === "number") {
     return String(node).includes(text);
   }
@@ -26,7 +45,39 @@ function includesText(node: unknown, text: string): boolean {
   return includesText(children, text);
 }
 
+function hasInputDefault(node: unknown, name: string, defaultValue: string): boolean {
+  node = expandNode(node);
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const element = node as {
+    props?: {
+      children?: unknown;
+      defaultValue?: unknown;
+      name?: unknown;
+    };
+  };
+
+  if (element.props?.name === name && element.props.defaultValue === defaultValue) {
+    return true;
+  }
+
+  const children = element.props?.children;
+
+  if (Array.isArray(children)) {
+    return children.some((child) => hasInputDefault(child, name, defaultValue));
+  }
+
+  return hasInputDefault(children, name, defaultValue);
+}
+
 describe("ListingsPage", () => {
+  beforeEach(() => {
+    vi.mocked(getActiveListings).mockReset();
+  });
+
   it("uses URL filters for active listing discovery", async () => {
     vi.mocked(getActiveListings).mockResolvedValue([]);
 
@@ -53,5 +104,87 @@ describe("ListingsPage", () => {
     });
     expect(includesText(page, "Min price")).toBe(true);
     expect(includesText(page, "Pet policy")).toBe(true);
+  });
+
+  it("accepts min and max rent aliases and keeps them visible after applying filters", async () => {
+    vi.mocked(getActiveListings).mockResolvedValue([]);
+
+    const page = await ListingsPage({
+      searchParams: Promise.resolve({
+        min: "1100",
+        max: "1600",
+      }),
+    });
+
+    expect(getActiveListings).toHaveBeenCalledWith({
+      rentMin: 1100,
+      rentMax: 1600,
+    });
+    expect(hasInputDefault(page, "rentMin", "1100")).toBe(true);
+    expect(hasInputDefault(page, "rentMax", "1600")).toBe(true);
+  });
+
+  it("ignores empty trailing filter params instead of dropping valid filters", async () => {
+    vi.mocked(getActiveListings).mockResolvedValue([]);
+
+    await ListingsPage({
+      searchParams: Promise.resolve({
+        rentMin: "1000",
+        rentMax: "1600",
+        type: "",
+        bedroomsMin: "",
+        bathroomsMin: "",
+        availableBy: "",
+        petPolicy: "",
+      }),
+    });
+
+    expect(getActiveListings).toHaveBeenCalledWith({
+      rentMin: 1000,
+      rentMax: 1600,
+      type: undefined,
+      bedroomsMin: undefined,
+      bathroomsMin: undefined,
+      availableBy: undefined,
+      petPolicy: undefined,
+    });
+  });
+
+  it("uses a single non-empty filter when the rest are empty", async () => {
+    vi.mocked(getActiveListings).mockResolvedValue([]);
+
+    await ListingsPage({
+      searchParams: Promise.resolve({
+        rentMin: "",
+        rentMax: "",
+        type: "ROOM",
+        bedroomsMin: "",
+        bathroomsMin: "",
+        availableBy: "",
+        petPolicy: "",
+      }),
+    });
+
+    expect(getActiveListings).toHaveBeenCalledWith({
+      rentMin: undefined,
+      rentMax: undefined,
+      type: "ROOM",
+      bedroomsMin: undefined,
+      bathroomsMin: undefined,
+      availableBy: undefined,
+      petPolicy: undefined,
+    });
+  });
+
+  it("shows filter actions in the header instead of a post listing action", async () => {
+    vi.mocked(getActiveListings).mockResolvedValue([]);
+
+    const page = await ListingsPage({
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(includesText(page, "Apply filters")).toBe(true);
+    expect(includesText(page, "Clear")).toBe(true);
+    expect(includesText(page, "Post listing")).toBe(false);
   });
 });

--- a/apps/web/src/app/listings/page.tsx
+++ b/apps/web/src/app/listings/page.tsx
@@ -1,10 +1,17 @@
 import Link from "next/link";
 
-import { ListingFilterForm } from "@/features/listings/components/listing-filter-form";
+import {
+  LISTING_FILTER_FORM_ID,
+  ListingFilterForm,
+} from "@/features/listings/components/listing-filter-form";
 import { ListingCard } from "@/features/listings/components/listing-card";
 import { ListingEmptyState } from "@/features/listings/components/listing-empty-state";
 import { getActiveListings } from "@/features/listings/queries";
-import { listingQuerySchema, type ListingQueryInput } from "@/features/listings/schemas";
+import {
+  listingQueryInputFromParams,
+  listingQuerySchema,
+  type ListingQueryInput,
+} from "@/features/listings/schemas";
 
 export const dynamic = "force-dynamic";
 
@@ -12,23 +19,15 @@ type ListingsPageProps = {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
-function firstParam(value: string | string[] | undefined) {
-  return Array.isArray(value) ? value[0] : value;
+function filterComponentKey(filters: ListingQueryInput) {
+  return JSON.stringify(filters);
 }
 
 async function parseListingFilters(
   searchParams: ListingsPageProps["searchParams"],
 ): Promise<ListingQueryInput> {
   const params = (await searchParams) ?? {};
-  const parsed = listingQuerySchema.safeParse({
-    type: firstParam(params.type),
-    rentMin: firstParam(params.rentMin),
-    rentMax: firstParam(params.rentMax),
-    bedroomsMin: firstParam(params.bedroomsMin),
-    bathroomsMin: firstParam(params.bathroomsMin),
-    availableBy: firstParam(params.availableBy),
-    petPolicy: firstParam(params.petPolicy),
-  });
+  const parsed = listingQuerySchema.safeParse(listingQueryInputFromParams(params));
 
   return parsed.success ? parsed.data : {};
 }
@@ -39,22 +38,31 @@ export default async function ListingsPage({ searchParams }: ListingsPageProps) 
 
   return (
     <main className="mx-auto max-w-6xl px-6 py-10">
-      <div className="mb-8 flex items-end justify-between gap-4">
+      <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="text-3xl font-semibold text-zinc-950">Listings</h1>
           <p className="mt-2 text-zinc-600">
             Apartments and rooms available near campus.
           </p>
         </div>
-        <Link
-          className="rounded-md bg-zinc-950 px-4 py-2 text-sm text-white"
-          href="/listings/new"
-        >
-          Post listing
-        </Link>
+        <div className="flex flex-wrap gap-3">
+          <button
+            form={LISTING_FILTER_FORM_ID}
+            type="submit"
+            className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+          >
+            Apply filters
+          </button>
+          <Link
+            href="/listings"
+            className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-950 hover:bg-zinc-100"
+          >
+            Clear
+          </Link>
+        </div>
       </div>
 
-      {ListingFilterForm({ filters })}
+      <ListingFilterForm key={filterComponentKey(filters)} filters={filters} />
 
       {listings.length === 0 ? (
         <ListingEmptyState />

--- a/apps/web/src/features/listings/components/listing-filter-form.test.tsx
+++ b/apps/web/src/features/listings/components/listing-filter-form.test.tsx
@@ -28,6 +28,12 @@ function hasInputDefault(node: unknown, name: string, defaultValue: string): boo
   return hasInputDefault(children, name, defaultValue);
 }
 
+function formKey(node: unknown) {
+  return typeof node === "object" && node !== null && "key" in node
+    ? String((node as { key: unknown }).key)
+    : null;
+}
+
 describe("ListingFilterForm", () => {
   it("renders current listing discovery filters", () => {
     const form = ListingFilterForm({
@@ -47,5 +53,20 @@ describe("ListingFilterForm", () => {
     expect(hasInputDefault(form, "bedroomsMin", "1")).toBe(true);
     expect(hasInputDefault(form, "bathroomsMin", "1.5")).toBe(true);
     expect(hasInputDefault(form, "availableBy", "2026-08-01")).toBe(true);
+  });
+
+  it("uses filter values as the form key so cleared dropdowns remount to defaults", () => {
+    const selectedForm = ListingFilterForm({
+      filters: {
+        type: "ROOM",
+        petPolicy: "PETS_ALLOWED",
+      },
+    });
+    const clearedForm = ListingFilterForm({
+      filters: {},
+    });
+
+    expect(formKey(selectedForm)).toBe("||ROOM||||PETS_ALLOWED");
+    expect(formKey(clearedForm)).toBe("||||||");
   });
 });

--- a/apps/web/src/features/listings/components/listing-filter-form.tsx
+++ b/apps/web/src/features/listings/components/listing-filter-form.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
-
 import { type ListingQueryInput } from "@/features/listings/schemas";
+
+export const LISTING_FILTER_FORM_ID = "listing-filter-form";
 
 type ListingFilterFormProps = {
   filters: ListingQueryInput;
@@ -10,9 +10,23 @@ function value(value: string | number | undefined) {
   return value === undefined ? "" : String(value);
 }
 
+function filterFormKey(filters: ListingQueryInput) {
+  return [
+    value(filters.rentMin),
+    value(filters.rentMax),
+    filters.type ?? "",
+    value(filters.bedroomsMin),
+    value(filters.bathroomsMin),
+    filters.availableBy ?? "",
+    filters.petPolicy ?? "",
+  ].join("|");
+}
+
 export function ListingFilterForm({ filters }: ListingFilterFormProps) {
   return (
     <form
+      key={filterFormKey(filters)}
+      id={LISTING_FILTER_FORM_ID}
       action="/listings"
       className="mb-8 grid gap-4 rounded-md border border-zinc-200 p-4"
     >
@@ -143,21 +157,6 @@ export function ListingFilterForm({ filters }: ListingFilterFormProps) {
             <option value="UNKNOWN">Not specified</option>
           </select>
         </div>
-      </div>
-
-      <div className="flex flex-wrap gap-3">
-        <button
-          type="submit"
-          className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
-        >
-          Apply filters
-        </button>
-        <Link
-          href="/listings"
-          className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-950 hover:bg-zinc-100"
-        >
-          Clear
-        </Link>
       </div>
     </form>
   );

--- a/apps/web/src/features/listings/schemas.test.ts
+++ b/apps/web/src/features/listings/schemas.test.ts
@@ -66,6 +66,29 @@ describe("listing API schemas", () => {
     });
   });
 
+  it("treats empty optional discovery filters as omitted", () => {
+    const parsed = listingQuerySchema.safeParse({
+      rentMin: "1000",
+      rentMax: "1600",
+      type: "",
+      bedroomsMin: "",
+      bathroomsMin: "",
+      availableBy: "",
+      petPolicy: "",
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.success ? parsed.data : null).toEqual({
+      rentMin: 1000,
+      rentMax: 1600,
+      type: undefined,
+      bedroomsMin: undefined,
+      bathroomsMin: undefined,
+      availableBy: undefined,
+      petPolicy: undefined,
+    });
+  });
+
   it("rejects inverted rent filters", () => {
     const parsed = listingQuerySchema.safeParse({
       rentMin: "1400",

--- a/apps/web/src/features/listings/schemas.ts
+++ b/apps/web/src/features/listings/schemas.ts
@@ -34,10 +34,18 @@ const optionalQueryNumberSchema = z.preprocess(
   (value) => (value === "" || value === null ? undefined : value),
   z.coerce.number().nonnegative().optional(),
 );
+const optionalListingTypeQuerySchema = z.preprocess(
+  (value) => (value === "" || value === null ? undefined : value),
+  listingTypeSchema.optional(),
+);
+const optionalPetPolicyQuerySchema = z.preprocess(
+  (value) => (value === "" || value === null ? undefined : value),
+  petPolicySchema.optional(),
+);
 
 export const listingQuerySchema = z
   .object({
-    type: listingTypeSchema.optional(),
+    type: optionalListingTypeQuerySchema,
     rentMin: optionalQueryNumberSchema,
     rentMax: optionalQueryNumberSchema,
     bedroomsMin: optionalQueryNumberSchema.pipe(z.number().int().optional()),
@@ -47,7 +55,7 @@ export const listingQuerySchema = z
         (value) => (value === "" || value === null ? undefined : value),
         z.string().date().optional(),
       ),
-    petPolicy: petPolicySchema.optional(),
+    petPolicy: optionalPetPolicyQuerySchema,
   })
   .refine(
     (value) =>
@@ -153,6 +161,29 @@ export type ListingApiResponse = z.infer<typeof listingResponseSchema>;
 export type ListingQueryInput = z.infer<typeof listingQuerySchema>;
 export type ListingCreateInput = z.infer<typeof listingCreateBodySchema>;
 export type ListingUpdateInput = z.infer<typeof listingUpdateBodySchema>;
+
+type ListingQueryParams =
+  | URLSearchParams
+  | Record<string, string | string[] | null | undefined>;
+
+function queryParam(params: ListingQueryParams, name: string) {
+  const value =
+    params instanceof URLSearchParams ? params.get(name) : params[name];
+
+  return Array.isArray(value) ? value[0] : (value ?? undefined);
+}
+
+export function listingQueryInputFromParams(params: ListingQueryParams) {
+  return {
+    type: queryParam(params, "type"),
+    rentMin: queryParam(params, "rentMin") ?? queryParam(params, "min"),
+    rentMax: queryParam(params, "rentMax") ?? queryParam(params, "max"),
+    bedroomsMin: queryParam(params, "bedroomsMin"),
+    bathroomsMin: queryParam(params, "bathroomsMin"),
+    availableBy: queryParam(params, "availableBy"),
+    petPolicy: queryParam(params, "petPolicy"),
+  };
+}
 
 type ListingForApi = {
   id: string;


### PR DESCRIPTION
## Summary
- Normalize empty listing filter query params so selected filters still apply when other fields are blank.
- Support `min`/`max` aliases alongside `rentMin`/`rentMax` for listing filters.
- Move listing filter actions to the listings page header and ensure Clear resets dropdown state.

## Root Cause
Blank dropdown params like `type=` and `petPolicy=` were treated as invalid enum values. That made filter parsing fail and caused the page to fall back to unfiltered listing reads.

## Validation
- `cd apps/web && npm run test` — 27 files, 70 tests passed
- `cd apps/web && npm run lint`
- `cd apps/web && npm run build` — passed outside sandbox due Turbopack worker permission requirements
- Browser smoke: Clear resets Home type and Pet policy to their default options