### PR TITLE
Add listing reviews and ratings

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
   contactPhone String?
   passwordHash String?
   listings     Listing[]
+  reviews      Review[]
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 }
@@ -63,6 +64,7 @@ model Listing {
   imageUrls         String[]
   ownerId           String?       @db.ObjectId
   owner             User?         @relation(fields: [ownerId], references: [id])
+  reviews           Review[]
   createdAt         DateTime      @default(now())
   updatedAt         DateTime      @updatedAt
 
@@ -77,4 +79,19 @@ model Listing {
   @@index([status, bathrooms])
   @@index([status, availableFrom])
   @@index([status, petPolicy])
+}
+
+model Review {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  listingId String   @db.ObjectId
+  listing   Listing  @relation(fields: [listingId], references: [id])
+  authorId  String   @db.ObjectId
+  author    User     @relation(fields: [authorId], references: [id])
+  body      String
+  rating    Int?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([listingId, createdAt])
+  @@index([authorId])
 }

--- a/apps/web/src/app/api/listings/[id]/reviews/route.test.ts
+++ b/apps/web/src/app/api/listings/[id]/reviews/route.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET, POST } from "@/app/api/listings/[id]/reviews/route";
+import {
+  createReview,
+  getReviewsForListing,
+} from "@/features/reviews/mutations";
+import { authRequired } from "@/server/api/errors";
+import { requireCurrentUser } from "@/server/auth/current-user";
+
+vi.mock("@/features/reviews/mutations", () => ({
+  createReview: vi.fn(),
+  getReviewsForListing: vi.fn(),
+}));
+
+vi.mock("@/server/auth/current-user", () => ({
+  requireCurrentUser: vi.fn(),
+}));
+
+const review = {
+  id: "507f1f77bcf86cd799439111",
+  listingId: "507f1f77bcf86cd799439011",
+  authorId: "507f1f77bcf86cd799439099",
+  authorName: "Owner",
+  body: "Helpful poster and accurate room details.",
+  rating: 5,
+  createdAt: new Date("2026-05-19T12:00:00.000Z"),
+  updatedAt: new Date("2026-05-19T12:00:00.000Z"),
+};
+
+describe("listing review APIs", () => {
+  beforeEach(() => {
+    vi.mocked(createReview).mockReset();
+    vi.mocked(getReviewsForListing).mockReset();
+    vi.mocked(requireCurrentUser).mockResolvedValue({
+      id: review.authorId,
+      email: "owner@example.com",
+      name: "Owner",
+    });
+  });
+
+  it("returns reviews for a listing in newest-first order", async () => {
+    vi.mocked(getReviewsForListing).mockResolvedValue([review]);
+
+    const response = await GET(
+      new Request(`http://localhost:3000/api/listings/${review.listingId}/reviews`),
+      { params: Promise.resolve({ id: review.listingId }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        reviews: [
+          {
+            ...review,
+            createdAt: "2026-05-19T12:00:00.000Z",
+            updatedAt: "2026-05-19T12:00:00.000Z",
+          },
+        ],
+      },
+    });
+    expect(getReviewsForListing).toHaveBeenCalledWith(review.listingId);
+  });
+
+  it("creates a review with an optional rating for the signed-in user", async () => {
+    vi.mocked(createReview).mockResolvedValue(review);
+
+    const response = await POST(
+      new Request(`http://localhost:3000/api/listings/${review.listingId}/reviews`, {
+        method: "POST",
+        body: JSON.stringify({
+          body: review.body,
+          rating: review.rating,
+        }),
+      }),
+      { params: Promise.resolve({ id: review.listingId }) },
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        review: {
+          id: review.id,
+          body: review.body,
+          rating: 5,
+        },
+      },
+    });
+    expect(createReview).toHaveBeenCalledWith(
+      review.listingId,
+      {
+        body: review.body,
+        rating: 5,
+      },
+      review.authorId,
+    );
+  });
+
+  it("returns validation errors for invalid review bodies", async () => {
+    const response = await POST(
+      new Request(`http://localhost:3000/api/listings/${review.listingId}/reviews`, {
+        method: "POST",
+        body: JSON.stringify({
+          body: "",
+          rating: 6,
+        }),
+      }),
+      { params: Promise.resolve({ id: review.listingId }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "VALIDATION_ERROR",
+      },
+    });
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("requires a signed-in user to create a review", async () => {
+    vi.mocked(requireCurrentUser).mockRejectedValue(authRequired());
+
+    const response = await POST(
+      new Request(`http://localhost:3000/api/listings/${review.listingId}/reviews`, {
+        method: "POST",
+        body: JSON.stringify({
+          body: review.body,
+          rating: review.rating,
+        }),
+      }),
+      { params: Promise.resolve({ id: review.listingId }) },
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "AUTH_REQUIRED",
+      },
+    });
+    expect(createReview).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/listings/[id]/reviews/route.ts
+++ b/apps/web/src/app/api/listings/[id]/reviews/route.ts
@@ -1,0 +1,61 @@
+import {
+  createReview,
+  getReviewsForListing,
+} from "@/features/reviews/mutations";
+import {
+  listingReviewsParamsSchema,
+  reviewCreateBodySchema,
+  reviewDetailResponseSchema,
+  reviewsResponseSchema,
+  serializeReview,
+} from "@/features/reviews/schemas";
+import { readJsonBody } from "@/server/api/request";
+import { apiData, throwIfInvalid, withApiErrorHandling } from "@/server/api/responses";
+import { requireCurrentUser } from "@/server/auth/current-user";
+
+export const dynamic = "force-dynamic";
+
+type ListingReviewsRouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function GET(
+  _request: Request,
+  context: ListingReviewsRouteContext,
+) {
+  return withApiErrorHandling(async () => {
+    const params = throwIfInvalid(
+      listingReviewsParamsSchema.safeParse(await context.params),
+    );
+    const reviews = await getReviewsForListing(params.id);
+
+    return apiData(
+      reviewsResponseSchema.parse({
+        reviews: reviews.map(serializeReview),
+      }),
+    );
+  });
+}
+
+export async function POST(
+  request: Request,
+  context: ListingReviewsRouteContext,
+) {
+  return withApiErrorHandling(async () => {
+    const currentUser = await requireCurrentUser();
+    const params = throwIfInvalid(
+      listingReviewsParamsSchema.safeParse(await context.params),
+    );
+    const body = throwIfInvalid(
+      reviewCreateBodySchema.safeParse(await readJsonBody(request)),
+    );
+    const review = await createReview(params.id, body, currentUser.id);
+
+    return apiData(
+      reviewDetailResponseSchema.parse({
+        review: review ? serializeReview(review) : null,
+      }),
+      { status: 201 },
+    );
+  });
+}

--- a/apps/web/src/app/api/reviews/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/reviews/[reviewId]/route.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DELETE, PATCH } from "@/app/api/reviews/[reviewId]/route";
+import { deleteReview, updateReview } from "@/features/reviews/mutations";
+import { authRequired, forbidden } from "@/server/api/errors";
+import { requireCurrentUser } from "@/server/auth/current-user";
+
+vi.mock("@/features/reviews/mutations", () => ({
+  deleteReview: vi.fn(),
+  updateReview: vi.fn(),
+}));
+
+vi.mock("@/server/auth/current-user", () => ({
+  requireCurrentUser: vi.fn(),
+}));
+
+const review = {
+  id: "507f1f77bcf86cd799439111",
+  listingId: "507f1f77bcf86cd799439011",
+  authorId: "507f1f77bcf86cd799439099",
+  authorName: "Owner",
+  body: "Updated review body.",
+  rating: 4,
+  createdAt: new Date("2026-05-19T12:00:00.000Z"),
+  updatedAt: new Date("2026-05-19T13:00:00.000Z"),
+};
+
+describe("review ownership APIs", () => {
+  beforeEach(() => {
+    vi.mocked(deleteReview).mockReset();
+    vi.mocked(updateReview).mockReset();
+    vi.mocked(requireCurrentUser).mockResolvedValue({
+      id: review.authorId,
+      email: "owner@example.com",
+      name: "Owner",
+    });
+  });
+
+  it("updates a review for the author", async () => {
+    vi.mocked(updateReview).mockResolvedValue(review);
+
+    const response = await PATCH(
+      new Request(`http://localhost:3000/api/reviews/${review.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          body: review.body,
+          rating: review.rating,
+        }),
+      }),
+      { params: Promise.resolve({ reviewId: review.id }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        review: {
+          id: review.id,
+          body: review.body,
+          rating: 4,
+        },
+      },
+    });
+    expect(updateReview).toHaveBeenCalledWith(
+      review.id,
+      {
+        body: review.body,
+        rating: review.rating,
+      },
+      review.authorId,
+    );
+  });
+
+  it("returns FORBIDDEN when another user edits a review", async () => {
+    vi.mocked(updateReview).mockRejectedValue(
+      forbidden("Only the review author can update this review."),
+    );
+
+    const response = await PATCH(
+      new Request(`http://localhost:3000/api/reviews/${review.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ body: "Not mine" }),
+      }),
+      { params: Promise.resolve({ reviewId: review.id }) },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("deletes a review for the author", async () => {
+    vi.mocked(deleteReview).mockResolvedValue(review);
+
+    const response = await DELETE(
+      new Request(`http://localhost:3000/api/reviews/${review.id}`, {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ reviewId: review.id }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        review: {
+          id: review.id,
+        },
+      },
+    });
+    expect(deleteReview).toHaveBeenCalledWith(review.id, review.authorId);
+  });
+
+  it("requires a signed-in user to update reviews", async () => {
+    vi.mocked(requireCurrentUser).mockRejectedValue(authRequired());
+
+    const response = await PATCH(
+      new Request(`http://localhost:3000/api/reviews/${review.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ body: review.body }),
+      }),
+      { params: Promise.resolve({ reviewId: review.id }) },
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "AUTH_REQUIRED",
+      },
+    });
+    expect(updateReview).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/reviews/[reviewId]/route.ts
+++ b/apps/web/src/app/api/reviews/[reviewId]/route.ts
@@ -1,0 +1,63 @@
+import {
+  deleteReview,
+  updateReview,
+} from "@/features/reviews/mutations";
+import {
+  reviewDetailResponseSchema,
+  reviewParamsSchema,
+  reviewUpdateBodySchema,
+  serializeReview,
+} from "@/features/reviews/schemas";
+import { reviewNotFound } from "@/server/api/errors";
+import { readJsonBody } from "@/server/api/request";
+import { apiData, throwIfInvalid, withApiErrorHandling } from "@/server/api/responses";
+import { requireCurrentUser } from "@/server/auth/current-user";
+
+export const dynamic = "force-dynamic";
+
+type ReviewRouteContext = {
+  params: Promise<{ reviewId: string }>;
+};
+
+export async function PATCH(request: Request, context: ReviewRouteContext) {
+  return withApiErrorHandling(async () => {
+    const currentUser = await requireCurrentUser();
+    const params = throwIfInvalid(
+      reviewParamsSchema.safeParse(await context.params),
+    );
+    const body = throwIfInvalid(
+      reviewUpdateBodySchema.safeParse(await readJsonBody(request)),
+    );
+    const review = await updateReview(params.reviewId, body, currentUser.id);
+
+    if (!review) {
+      throw reviewNotFound(params.reviewId);
+    }
+
+    return apiData(
+      reviewDetailResponseSchema.parse({
+        review: serializeReview(review),
+      }),
+    );
+  });
+}
+
+export async function DELETE(_request: Request, context: ReviewRouteContext) {
+  return withApiErrorHandling(async () => {
+    const currentUser = await requireCurrentUser();
+    const params = throwIfInvalid(
+      reviewParamsSchema.safeParse(await context.params),
+    );
+    const review = await deleteReview(params.reviewId, currentUser.id);
+
+    if (!review) {
+      throw reviewNotFound(params.reviewId);
+    }
+
+    return apiData(
+      reviewDetailResponseSchema.parse({
+        review: serializeReview(review),
+      }),
+    );
+  });
+}

--- a/apps/web/src/app/listings/[id]/page.test.tsx
+++ b/apps/web/src/app/listings/[id]/page.test.tsx
@@ -1,11 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ListingDetailPage from "@/app/listings/[id]/page";
 import { getListingById } from "@/features/listings/queries";
+import { getReviewsForListing } from "@/features/reviews/mutations";
 import { auth } from "@/server/auth/auth";
 
 vi.mock("@/features/listings/queries", () => ({
   getListingById: vi.fn(),
+}));
+
+vi.mock("@/features/reviews/mutations", () => ({
+  getReviewsForListing: vi.fn(),
 }));
 
 vi.mock("@/server/auth/auth", () => ({
@@ -65,6 +70,10 @@ function hasHref(node: unknown, href: string): boolean {
 }
 
 describe("ListingDetailPage", () => {
+  beforeEach(() => {
+    vi.mocked(getReviewsForListing).mockResolvedValue([]);
+  });
+
   it("shows edit controls for the listing owner", async () => {
     vi.mocked(getListingById).mockResolvedValue(listing);
     vi.mocked(auth).mockResolvedValue({
@@ -79,5 +88,32 @@ describe("ListingDetailPage", () => {
     });
 
     expect(hasHref(page, `/listings/${listing.id}/edit`)).toBe(true);
+  });
+
+  it("loads and renders reviews for the listing", async () => {
+    vi.mocked(getListingById).mockResolvedValue(listing);
+    vi.mocked(getReviewsForListing).mockResolvedValue([
+      {
+        id: "507f1f77bcf86cd799439111",
+        listingId: listing.id,
+        authorId: "507f1f77bcf86cd799439088",
+        authorName: "Renter One",
+        body: "The room details were accurate and the poster replied quickly.",
+        rating: 5,
+        createdAt: new Date("2026-05-19T12:00:00.000Z"),
+        updatedAt: new Date("2026-05-19T12:00:00.000Z"),
+      },
+    ]);
+    vi.mocked(auth).mockResolvedValue(null);
+
+    const page = await ListingDetailPage({
+      params: Promise.resolve({ id: listing.id }),
+    });
+
+    expect(JSON.stringify(page)).toContain(
+      "The room details were accurate and the poster replied quickly.",
+    );
+    expect(JSON.stringify(page)).toContain('"rating":5');
+    expect(getReviewsForListing).toHaveBeenCalledWith(listing.id);
   });
 });

--- a/apps/web/src/app/listings/[id]/page.tsx
+++ b/apps/web/src/app/listings/[id]/page.tsx
@@ -1,6 +1,9 @@
 import { getListingById } from "@/features/listings/queries";
 import { ListingArchiveButton } from "@/features/listings/components/listing-archive-button";
 import { ListingImageGallery } from "@/features/listings/components/listing-image-gallery";
+import { ReviewSection } from "@/features/reviews/components/review-section";
+import { getReviewsForListing } from "@/features/reviews/mutations";
+import { serializeReview } from "@/features/reviews/schemas";
 import { auth } from "@/server/auth/auth";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -15,7 +18,11 @@ export default async function ListingDetailPage({
   params,
 }: ListingDetailPageProps) {
   const { id } = await params;
-  const [listing, session] = await Promise.all([getListingById(id), auth()]);
+  const [listing, reviews, session] = await Promise.all([
+    getListingById(id),
+    getReviewsForListing(id),
+    auth(),
+  ]);
 
   if (!listing) {
     notFound();
@@ -129,6 +136,12 @@ export default async function ListingDetailPage({
           </div>
         </div>
       ) : null}
+
+      <ReviewSection
+        listingId={listing.id}
+        initialReviews={reviews.map(serializeReview)}
+        currentUserId={session?.user?.id ?? null}
+      />
     </main>
   );
 }

--- a/apps/web/src/features/reviews/components/review-section.tsx
+++ b/apps/web/src/features/reviews/components/review-section.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+
+import type { ReviewApiResponse } from "@/features/reviews/schemas";
+
+type ReviewSectionProps = {
+  listingId: string;
+  initialReviews: ReviewApiResponse[];
+  currentUserId?: string | null;
+};
+
+type ApiErrorBody = {
+  error?: {
+    message?: string;
+  };
+};
+
+async function readErrorMessage(response: Response, fallback: string) {
+  const body = (await response.json().catch(() => null)) as ApiErrorBody | null;
+  return body?.error?.message ?? fallback;
+}
+
+function reviewAuthor(review: ReviewApiResponse) {
+  return review.authorName ?? "AllApartments user";
+}
+
+export function ReviewSection({
+  listingId,
+  initialReviews,
+  currentUserId,
+}: ReviewSectionProps) {
+  const router = useRouter();
+  const [reviews, setReviews] = useState(initialReviews);
+  const [editingReviewId, setEditingReviewId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSignedIn = Boolean(currentUserId);
+
+  async function createReview(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const ratingValue = String(formData.get("rating") ?? "");
+
+    try {
+      const response = await fetch(`/api/listings/${listingId}/reviews`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          body: String(formData.get("body") ?? ""),
+          rating: ratingValue ? Number(ratingValue) : null,
+        }),
+      });
+
+      if (!response.ok) {
+        setError(await readErrorMessage(response, "Could not add review."));
+        return;
+      }
+
+      const payload = (await response.json()) as {
+        data?: { review?: ReviewApiResponse };
+      };
+
+      if (payload.data?.review) {
+        setReviews((current) => [payload.data!.review!, ...current]);
+      }
+
+      form.reset();
+      router.refresh();
+    } catch {
+      setError("Could not add review.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function updateReview(event: FormEvent<HTMLFormElement>, reviewId: string) {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    const formData = new FormData(event.currentTarget);
+    const ratingValue = String(formData.get("rating") ?? "");
+
+    try {
+      const response = await fetch(`/api/reviews/${reviewId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          body: String(formData.get("body") ?? ""),
+          rating: ratingValue ? Number(ratingValue) : null,
+        }),
+      });
+
+      if (!response.ok) {
+        setError(await readErrorMessage(response, "Could not update review."));
+        return;
+      }
+
+      const payload = (await response.json()) as {
+        data?: { review?: ReviewApiResponse };
+      };
+
+      if (payload.data?.review) {
+        setReviews((current) =>
+          current.map((review) =>
+            review.id === reviewId ? payload.data!.review! : review,
+          ),
+        );
+      }
+
+      setEditingReviewId(null);
+      router.refresh();
+    } catch {
+      setError("Could not update review.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function deleteReview(reviewId: string) {
+    if (!window.confirm("Delete this review?")) {
+      return;
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch(`/api/reviews/${reviewId}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        setError(await readErrorMessage(response, "Could not delete review."));
+        return;
+      }
+
+      setReviews((current) => current.filter((review) => review.id !== reviewId));
+      router.refresh();
+    } catch {
+      setError("Could not delete review.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="mt-10 border-t border-zinc-200 pt-8">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold text-zinc-950">
+            Reviews and comments
+          </h2>
+          <p className="mt-1 text-sm text-zinc-600">
+            {reviews.length === 0
+              ? "No reviews yet."
+              : `${reviews.length} review${reviews.length === 1 ? "" : "s"}`}
+          </p>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="mt-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+
+      {isSignedIn ? (
+        <form onSubmit={createReview} className="mt-5 grid gap-3">
+          <label htmlFor="review-body" className="text-sm font-medium text-zinc-800">
+            Add a comment
+          </label>
+          <textarea
+            id="review-body"
+            name="body"
+            required
+            rows={4}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            placeholder="Share what future renters should know."
+          />
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="grid gap-2">
+              <label htmlFor="review-rating" className="text-sm font-medium text-zinc-800">
+                Rating
+              </label>
+              <select
+                id="review-rating"
+                name="rating"
+                defaultValue=""
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+              >
+                <option value="">No rating</option>
+                <option value="5">5</option>
+                <option value="4">4</option>
+                <option value="3">3</option>
+                <option value="2">2</option>
+                <option value="1">1</option>
+              </select>
+            </div>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+            >
+              {isSubmitting ? "Posting..." : "Post review"}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <p className="mt-5 rounded-md border border-zinc-200 px-4 py-3 text-sm text-zinc-700">
+          Sign in to add a comment or rating.
+        </p>
+      )}
+
+      <div className="mt-6 grid gap-5">
+        {reviews.map((review) => {
+          const isAuthor = currentUserId === review.authorId;
+          const isEditing = editingReviewId === review.id;
+
+          return (
+            <article key={review.id} className="border-t border-zinc-200 pt-5">
+              {isEditing ? (
+                <form
+                  onSubmit={(event) => updateReview(event, review.id)}
+                  className="grid gap-3"
+                >
+                  <textarea
+                    name="body"
+                    required
+                    rows={4}
+                    defaultValue={review.body}
+                    className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+                  />
+                  <div className="flex flex-wrap items-center gap-3">
+                    <select
+                      name="rating"
+                      defaultValue={review.rating ?? ""}
+                      className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+                    >
+                      <option value="">No rating</option>
+                      <option value="5">5</option>
+                      <option value="4">4</option>
+                      <option value="3">3</option>
+                      <option value="2">2</option>
+                      <option value="1">1</option>
+                    </select>
+                    <button
+                      type="submit"
+                      disabled={isSubmitting}
+                      className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+                    >
+                      Save
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditingReviewId(null)}
+                      className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-800 hover:bg-zinc-50"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              ) : (
+                <div className="grid gap-2">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <p className="text-sm font-medium text-zinc-950">
+                      {reviewAuthor(review)}
+                    </p>
+                    {review.rating ? (
+                      <p className="text-sm font-semibold text-emerald-700">
+                        {review.rating}/5
+                      </p>
+                    ) : null}
+                  </div>
+                  <p className="leading-7 text-zinc-700">{review.body}</p>
+                  {isAuthor ? (
+                    <div className="flex flex-wrap gap-3">
+                      <button
+                        type="button"
+                        onClick={() => setEditingReviewId(review.id)}
+                        className="text-sm font-medium text-zinc-950 underline-offset-4 hover:underline"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void deleteReview(review.id)}
+                        disabled={isSubmitting}
+                        className="text-sm font-medium text-red-700 underline-offset-4 hover:underline disabled:text-red-300"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/reviews/mutations.test.ts
+++ b/apps/web/src/features/reviews/mutations.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createReview,
+  deleteReview,
+  getReviewsForListing,
+  updateReview,
+} from "@/features/reviews/mutations";
+import { prisma } from "@/server/db/prisma";
+
+vi.mock("@/server/db/prisma", () => ({
+  prisma: {
+    review: {
+      create: vi.fn(),
+      delete: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+const reviewId = "507f1f77bcf86cd799439111";
+const listingId = "507f1f77bcf86cd799439011";
+const authorId = "507f1f77bcf86cd799439099";
+
+describe("review mutations", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.review.create).mockReset();
+    vi.mocked(prisma.review.delete).mockReset();
+    vi.mocked(prisma.review.findMany).mockReset();
+    vi.mocked(prisma.review.findUnique).mockReset();
+    vi.mocked(prisma.review.update).mockReset();
+    process.env.DATABASE_URL = "mongodb://example.test/allapartments";
+  });
+
+  it("reads listing reviews newest first with author display data", async () => {
+    vi.mocked(prisma.review.findMany).mockResolvedValue([]);
+
+    await getReviewsForListing(listingId);
+
+    expect(prisma.review.findMany).toHaveBeenCalledWith({
+      where: {
+        listingId,
+      },
+      include: {
+        author: {
+          select: {
+            name: true,
+            email: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+  });
+
+  it("creates a review connected to the listing and signed-in author", async () => {
+    vi.mocked(prisma.review.create).mockResolvedValue({});
+
+    await createReview(
+      listingId,
+      {
+        body: "Accurate listing and quick reply.",
+        rating: 5,
+      },
+      authorId,
+    );
+
+    expect(prisma.review.create).toHaveBeenCalledWith({
+      data: {
+        body: "Accurate listing and quick reply.",
+        rating: 5,
+        listing: {
+          connect: {
+            id: listingId,
+          },
+        },
+        author: {
+          connect: {
+            id: authorId,
+          },
+        },
+      },
+      include: {
+        author: {
+          select: {
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
+  });
+
+  it("blocks updates from users who did not author the review", async () => {
+    vi.mocked(prisma.review.findUnique).mockResolvedValue({
+      id: reviewId,
+      authorId: "507f1f77bcf86cd799439088",
+    });
+
+    await expect(
+      updateReview(reviewId, { body: "Not mine" }, authorId),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(prisma.review.update).not.toHaveBeenCalled();
+  });
+
+  it("updates reviews owned by the signed-in author", async () => {
+    vi.mocked(prisma.review.findUnique).mockResolvedValue({
+      id: reviewId,
+      authorId,
+    });
+    vi.mocked(prisma.review.update).mockResolvedValue({});
+
+    await updateReview(reviewId, { body: "Updated", rating: 4 }, authorId);
+
+    expect(prisma.review.update).toHaveBeenCalledWith({
+      where: {
+        id: reviewId,
+      },
+      data: {
+        body: "Updated",
+        rating: 4,
+      },
+      include: {
+        author: {
+          select: {
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
+  });
+
+  it("deletes reviews owned by the signed-in author", async () => {
+    vi.mocked(prisma.review.findUnique).mockResolvedValue({
+      id: reviewId,
+      authorId,
+    });
+    vi.mocked(prisma.review.delete).mockResolvedValue({});
+
+    await deleteReview(reviewId, authorId);
+
+    expect(prisma.review.delete).toHaveBeenCalledWith({
+      where: {
+        id: reviewId,
+      },
+      include: {
+        author: {
+          select: {
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
+  });
+});

--- a/apps/web/src/features/reviews/mutations.ts
+++ b/apps/web/src/features/reviews/mutations.ts
@@ -1,0 +1,131 @@
+import { forbidden } from "@/server/api/errors";
+import { prisma } from "@/server/db/prisma";
+
+import {
+  type ReviewCreateInput,
+  type ReviewUpdateInput,
+} from "./schemas";
+
+function hasDatabaseUrl() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+const reviewInclude = {
+  author: {
+    select: {
+      name: true,
+      email: true,
+    },
+  },
+};
+
+export async function getReviewsForListing(listingId: string) {
+  if (!hasDatabaseUrl()) {
+    return [];
+  }
+
+  return prisma.review.findMany({
+    where: {
+      listingId,
+    },
+    include: reviewInclude,
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+}
+
+export async function createReview(
+  listingId: string,
+  input: ReviewCreateInput,
+  authorId: string,
+) {
+  if (!hasDatabaseUrl()) {
+    return null;
+  }
+
+  return prisma.review.create({
+    data: {
+      body: input.body,
+      rating: input.rating,
+      listing: {
+        connect: {
+          id: listingId,
+        },
+      },
+      author: {
+        connect: {
+          id: authorId,
+        },
+      },
+    },
+    include: reviewInclude,
+  });
+}
+
+export async function updateReview(
+  reviewId: string,
+  input: ReviewUpdateInput,
+  authorId: string,
+) {
+  if (!hasDatabaseUrl()) {
+    return null;
+  }
+
+  const existing = await prisma.review.findUnique({
+    where: {
+      id: reviewId,
+    },
+    select: {
+      id: true,
+      authorId: true,
+    },
+  });
+
+  if (!existing) {
+    return null;
+  }
+
+  if (existing.authorId !== authorId) {
+    throw forbidden("Only the review author can update this review.");
+  }
+
+  return prisma.review.update({
+    where: {
+      id: reviewId,
+    },
+    data: input,
+    include: reviewInclude,
+  });
+}
+
+export async function deleteReview(reviewId: string, authorId: string) {
+  if (!hasDatabaseUrl()) {
+    return null;
+  }
+
+  const existing = await prisma.review.findUnique({
+    where: {
+      id: reviewId,
+    },
+    select: {
+      id: true,
+      authorId: true,
+    },
+  });
+
+  if (!existing) {
+    return null;
+  }
+
+  if (existing.authorId !== authorId) {
+    throw forbidden("Only the review author can delete this review.");
+  }
+
+  return prisma.review.delete({
+    where: {
+      id: reviewId,
+    },
+    include: reviewInclude,
+  });
+}

--- a/apps/web/src/features/reviews/schemas.ts
+++ b/apps/web/src/features/reviews/schemas.ts
@@ -1,0 +1,77 @@
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+
+extendZodWithOpenApi(z);
+
+export const reviewParamsSchema = z.object({
+  reviewId: z.string().trim().min(1, "Review id is required."),
+});
+
+export const listingReviewsParamsSchema = z.object({
+  id: z.string().trim().min(1, "Listing id is required."),
+});
+
+export const reviewResponseSchema = z.object({
+  id: z.string(),
+  listingId: z.string(),
+  authorId: z.string(),
+  authorName: z.string().nullable(),
+  body: z.string(),
+  rating: z.number().int().min(1).max(5).nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const reviewsResponseSchema = z.object({
+  reviews: z.array(reviewResponseSchema),
+});
+
+export const reviewDetailResponseSchema = z.object({
+  review: reviewResponseSchema,
+});
+
+export const reviewCreateBodySchema = z.object({
+  body: z.string().trim().min(1, "Review body is required.").max(2000),
+  rating: z.number().int().min(1).max(5).nullable().default(null),
+});
+
+export const reviewUpdateBodySchema = z
+  .object({
+    body: z.string().trim().min(1, "Review body is required.").max(2000).optional(),
+    rating: z.number().int().min(1).max(5).nullable().optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one review field is required.",
+  });
+
+export type ReviewApiResponse = z.infer<typeof reviewResponseSchema>;
+export type ReviewCreateInput = z.infer<typeof reviewCreateBodySchema>;
+export type ReviewUpdateInput = z.infer<typeof reviewUpdateBodySchema>;
+
+type ReviewForApi = {
+  id: string;
+  listingId: string;
+  authorId: string;
+  author?: {
+    name?: string | null;
+    email?: string | null;
+  } | null;
+  authorName?: string | null;
+  body: string;
+  rating: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export function serializeReview(review: ReviewForApi): ReviewApiResponse {
+  return reviewResponseSchema.parse({
+    id: review.id,
+    listingId: review.listingId,
+    authorId: review.authorId,
+    authorName: review.authorName ?? review.author?.name ?? review.author?.email ?? null,
+    body: review.body,
+    rating: review.rating,
+    createdAt: review.createdAt.toISOString(),
+    updatedAt: review.updatedAt.toISOString(),
+  });
+}

--- a/apps/web/src/server/api/errors.ts
+++ b/apps/web/src/server/api/errors.ts
@@ -5,6 +5,7 @@ export type ApiErrorCode =
   | "FORBIDDEN"
   | "EMAIL_ALREADY_EXISTS"
   | "LISTING_NOT_FOUND"
+  | "REVIEW_NOT_FOUND"
   | "INTERNAL_SERVER_ERROR";
 
 export type ApiErrorInit = {
@@ -107,6 +108,15 @@ export function listingNotFound(id: string) {
   return new ApiError({
     code: "LISTING_NOT_FOUND",
     message: "Listing was not found.",
+    status: 404,
+    details: { id },
+  });
+}
+
+export function reviewNotFound(id: string) {
+  return new ApiError({
+    code: "REVIEW_NOT_FOUND",
+    message: "Review was not found.",
     status: 404,
     details: { id },
   });

--- a/apps/web/src/server/api/openapi.test.ts
+++ b/apps/web/src/server/api/openapi.test.ts
@@ -13,9 +13,15 @@ describe("OpenAPI document", () => {
     expect(document.paths["/api/listings/{id}"]?.get).toBeDefined();
     expect(document.paths["/api/listings/{id}"]?.patch).toBeDefined();
     expect(document.paths["/api/listings/{id}"]?.delete).toBeDefined();
+    expect(document.paths["/api/listings/{id}/reviews"]?.get).toBeDefined();
+    expect(document.paths["/api/listings/{id}/reviews"]?.post).toBeDefined();
+    expect(document.paths["/api/reviews/{reviewId}"]?.patch).toBeDefined();
+    expect(document.paths["/api/reviews/{reviewId}"]?.delete).toBeDefined();
     expect(document.components?.schemas?.ApiErrorResponse).toBeDefined();
     expect(document.components?.schemas?.RegisterResponse).toBeDefined();
+    expect(document.components?.schemas?.ReviewDetailResponse).toBeDefined();
     expect(document.paths["/api/listings"]?.post?.responses?.[401]).toBeDefined();
     expect(document.paths["/api/listings/{id}"]?.patch?.responses?.[403]).toBeDefined();
+    expect(document.paths["/api/reviews/{reviewId}"]?.patch?.responses?.[403]).toBeDefined();
   });
 });

--- a/apps/web/src/server/api/openapi.ts
+++ b/apps/web/src/server/api/openapi.ts
@@ -17,6 +17,14 @@ import {
   listingUpdateBodySchema,
   listingsResponseSchema,
 } from "@/features/listings/schemas";
+import {
+  listingReviewsParamsSchema,
+  reviewCreateBodySchema,
+  reviewDetailResponseSchema,
+  reviewParamsSchema,
+  reviewUpdateBodySchema,
+  reviewsResponseSchema,
+} from "@/features/reviews/schemas";
 
 extendZodWithOpenApi(z);
 
@@ -61,6 +69,10 @@ export function createOpenApiDocument() {
   registry.register("ListingUpdateBody", listingUpdateBodySchema);
   registry.register("ListingsResponse", listingsResponseSchema);
   registry.register("ListingDetailResponse", listingDetailResponseSchema);
+  registry.register("ReviewCreateBody", reviewCreateBodySchema);
+  registry.register("ReviewUpdateBody", reviewUpdateBodySchema);
+  registry.register("ReviewsResponse", reviewsResponseSchema);
+  registry.register("ReviewDetailResponse", reviewDetailResponseSchema);
 
   registry.registerPath({
     method: "post",
@@ -162,6 +174,78 @@ export function createOpenApiDocument() {
       401: jsonContent(apiErrorResponseSchema, "Authentication required response."),
       403: jsonContent(apiErrorResponseSchema, "Forbidden owner-check response."),
       404: jsonContent(apiErrorResponseSchema, "Listing not found response."),
+      500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
+    },
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/listings/{id}/reviews",
+    summary: "List listing reviews",
+    description: "Returns comments and optional ratings for a listing.",
+    request: {
+      params: listingReviewsParamsSchema,
+    },
+    responses: {
+      200: jsonContent(reviewsResponseSchema, "Listing reviews response."),
+      400: jsonContent(apiErrorResponseSchema, "Validation error response."),
+      500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/api/listings/{id}/reviews",
+    summary: "Create listing review",
+    description:
+      "Creates a comment and optional 1-5 rating for the signed-in user.",
+    request: {
+      params: listingReviewsParamsSchema,
+      body: jsonRequestBody(reviewCreateBodySchema, "Review create payload."),
+    },
+    responses: {
+      201: jsonContent(reviewDetailResponseSchema, "Created review response."),
+      400: jsonContent(apiErrorResponseSchema, "Validation error response."),
+      401: jsonContent(apiErrorResponseSchema, "Authentication required response."),
+      500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
+    },
+  });
+
+  registry.registerPath({
+    method: "patch",
+    path: "/api/reviews/{reviewId}",
+    summary: "Update review",
+    description:
+      "Updates a review owned by the signed-in user.",
+    request: {
+      params: reviewParamsSchema,
+      body: jsonRequestBody(reviewUpdateBodySchema, "Review update payload."),
+    },
+    responses: {
+      200: jsonContent(reviewDetailResponseSchema, "Updated review response."),
+      400: jsonContent(apiErrorResponseSchema, "Validation error response."),
+      401: jsonContent(apiErrorResponseSchema, "Authentication required response."),
+      403: jsonContent(apiErrorResponseSchema, "Forbidden author-check response."),
+      404: jsonContent(apiErrorResponseSchema, "Review not found response."),
+      500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/api/reviews/{reviewId}",
+    summary: "Delete review",
+    description:
+      "Deletes a review owned by the signed-in user.",
+    request: {
+      params: reviewParamsSchema,
+    },
+    responses: {
+      200: jsonContent(reviewDetailResponseSchema, "Deleted review response."),
+      400: jsonContent(apiErrorResponseSchema, "Validation error response."),
+      401: jsonContent(apiErrorResponseSchema, "Authentication required response."),
+      403: jsonContent(apiErrorResponseSchema, "Forbidden author-check response."),
+      404: jsonContent(apiErrorResponseSchema, "Review not found response."),
       500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
     },
   });


### PR DESCRIPTION
## Summary
- Add a Prisma Review model connected to listings and users.
- Add review/comment APIs for listing-level create/list and review-level edit/delete with author ownership checks.
- Add schema-driven validation, OpenAPI/Swagger docs, and listing detail UI for comments plus optional 1-5 ratings.

## Validation
- `cd apps/web && npm test` — 30 files, 84 tests passed.
- `cd apps/web && npm run lint` — passed.
- `cd apps/web && npm run build` — passed when rerun outside the sandbox after Turbopack hit the known local helper port restriction.
- User manually verified UI scenarios: create, edit, delete, rating, and cross-user ownership behavior.