### PR TITLE
Add dev seed data

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,35 +1,46 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# AllApartments Web
+
+Local-first Next.js app for the StCloudAptss migration.
 
 ## Getting Started
 
-First, run the development server:
+Install dependencies, then run the development server:
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Dev Data
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+The app uses `DATABASE_URL` from `.env.local`. To sync indexes and seed local/dev data:
 
-## Learn More
+```bash
+npx prisma db push
+npm run db:seed
+```
 
-To learn more about Next.js, take a look at the following resources:
+Seeded accounts all use the password `Password123!`:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- `owner.one@example.com`
+- `owner.two@example.com`
+- `renter.one@example.com`
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+The seed command is idempotent. It upserts fixed users, listings, and reviews so local testing has stable data.
 
-## Deploy on Vercel
+## Checks
+
+```bash
+npm test
+npm run lint
+npm run build
+```
+
+## API Docs
+
+Run the app locally and open [http://localhost:3000/api-docs](http://localhost:3000/api-docs).
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "db:seed": "node prisma/seed.mjs"
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^8.5.0",

--- a/apps/web/prisma/seed-data.mjs
+++ b/apps/web/prisma/seed-data.mjs
@@ -1,0 +1,260 @@
+export const DEV_PASSWORD = "Password123!";
+
+export const DEV_USERS = [
+  {
+    id: "66a000000000000000000101",
+    email: "owner.one@example.com",
+    name: "Owner One",
+    contactEmail: "owner.one@example.com",
+    contactPhone: "320-555-0101",
+  },
+  {
+    id: "66a000000000000000000102",
+    email: "owner.two@example.com",
+    name: "Owner Two",
+    contactEmail: "owner.two@example.com",
+    contactPhone: "320-555-0102",
+  },
+  {
+    id: "66a000000000000000000103",
+    email: "renter.one@example.com",
+    name: "Renter One",
+    contactEmail: "renter.one@example.com",
+    contactPhone: "320-555-0103",
+  },
+];
+
+export const DEV_LISTINGS = [
+  {
+    id: "66a000000000000000000201",
+    ownerId: DEV_USERS[0].id,
+    title: "Seeded studio near campus",
+    type: "APARTMENT",
+    status: "ACTIVE",
+    description:
+      "Compact studio with quiet study space, fast internet, and a short walk to campus.",
+    rent: 925,
+    deposit: 925,
+    utilitiesIncluded: false,
+    availableFrom: new Date("2026-06-01T00:00:00.000Z"),
+    leaseDuration: "12 months",
+    address: "410 5th Ave S, Saint Cloud, MN",
+    distanceToCampus: "0.4 miles",
+    contactEmail: DEV_USERS[0].contactEmail,
+    contactPhone: DEV_USERS[0].contactPhone,
+    bedrooms: 0,
+    bathrooms: 1,
+    petPolicy: "CATS_ONLY",
+    amenities: ["Laundry", "Parking", "High-speed internet"],
+    imageUrls: [],
+  },
+  {
+    id: "66a000000000000000000202",
+    ownerId: DEV_USERS[0].id,
+    title: "Seeded private room in shared house",
+    type: "ROOM",
+    status: "ACTIVE",
+    description:
+      "Private room in a shared house with two roommates, in-unit laundry, and flexible move-in.",
+    rent: 650,
+    deposit: 500,
+    utilitiesIncluded: true,
+    availableFrom: new Date("2026-07-01T00:00:00.000Z"),
+    leaseDuration: "Academic year",
+    address: "720 4th Ave S, Saint Cloud, MN",
+    distanceToCampus: "0.2 miles",
+    contactEmail: DEV_USERS[0].contactEmail,
+    contactPhone: DEV_USERS[0].contactPhone,
+    bedrooms: 1,
+    bathrooms: 1,
+    petPolicy: "NO_PETS",
+    amenities: ["Utilities included", "Laundry", "Furnished"],
+    imageUrls: [],
+  },
+  {
+    id: "66a000000000000000000203",
+    ownerId: DEV_USERS[1].id,
+    title: "Seeded two bedroom by downtown",
+    type: "APARTMENT",
+    status: "ACTIVE",
+    description:
+      "Two bedroom apartment close to downtown routes with parking and a larger kitchen.",
+    rent: 1350,
+    deposit: 1000,
+    utilitiesIncluded: false,
+    availableFrom: new Date("2026-08-15T00:00:00.000Z"),
+    leaseDuration: "12 months",
+    address: "120 7th Ave N, Saint Cloud, MN",
+    distanceToCampus: "1.1 miles",
+    contactEmail: DEV_USERS[1].contactEmail,
+    contactPhone: DEV_USERS[1].contactPhone,
+    bedrooms: 2,
+    bathrooms: 1,
+    petPolicy: "PETS_ALLOWED",
+    amenities: ["Parking", "Dishwasher", "Pet friendly"],
+    imageUrls: [],
+  },
+  {
+    id: "66a000000000000000000204",
+    ownerId: DEV_USERS[1].id,
+    title: "Seeded roommate lead for fall",
+    type: "ROOMMATE",
+    status: "ACTIVE",
+    description:
+      "Looking for one roommate to join a fall lease near bus routes and campus.",
+    rent: 575,
+    deposit: null,
+    utilitiesIncluded: true,
+    availableFrom: new Date("2026-08-01T00:00:00.000Z"),
+    leaseDuration: "Fall and spring semesters",
+    address: null,
+    distanceToCampus: "0.8 miles",
+    contactEmail: DEV_USERS[1].contactEmail,
+    contactPhone: DEV_USERS[1].contactPhone,
+    bedrooms: 1,
+    bathrooms: 1,
+    petPolicy: "UNKNOWN",
+    amenities: ["Bus route", "Utilities included"],
+    imageUrls: [],
+  },
+];
+
+export const DEV_REVIEWS = [
+  {
+    id: "66a000000000000000000301",
+    listingId: DEV_LISTINGS[0].id,
+    authorId: DEV_USERS[2].id,
+    body: "Clean unit and the owner responded quickly to questions.",
+    rating: 5,
+  },
+  {
+    id: "66a000000000000000000302",
+    listingId: DEV_LISTINGS[1].id,
+    authorId: DEV_USERS[2].id,
+    body: "Good option if you want utilities included and a short walk.",
+    rating: 4,
+  },
+  {
+    id: "66a000000000000000000303",
+    listingId: DEV_LISTINGS[2].id,
+    authorId: DEV_USERS[0].id,
+    body: "Parking is useful here, especially in winter.",
+    rating: 4,
+  },
+  {
+    id: "66a000000000000000000304",
+    listingId: DEV_LISTINGS[3].id,
+    authorId: DEV_USERS[2].id,
+    body: "The roommate expectations were clear in the listing.",
+    rating: null,
+  },
+];
+
+function userWriteData(user, passwordHash) {
+  return {
+    email: user.email,
+    name: user.name,
+    contactEmail: user.contactEmail,
+    contactPhone: user.contactPhone,
+    passwordHash,
+  };
+}
+
+function listingWriteData(listing) {
+  return {
+    title: listing.title,
+    type: listing.type,
+    status: listing.status,
+    description: listing.description,
+    rent: listing.rent,
+    deposit: listing.deposit,
+    utilitiesIncluded: listing.utilitiesIncluded,
+    availableFrom: listing.availableFrom,
+    leaseDuration: listing.leaseDuration,
+    address: listing.address,
+    distanceToCampus: listing.distanceToCampus,
+    contactEmail: listing.contactEmail,
+    contactPhone: listing.contactPhone,
+    bedrooms: listing.bedrooms,
+    bathrooms: listing.bathrooms,
+    petPolicy: listing.petPolicy,
+    amenities: listing.amenities,
+    imageUrls: listing.imageUrls,
+    owner: {
+      connect: {
+        id: listing.ownerId,
+      },
+    },
+  };
+}
+
+function reviewWriteData(review) {
+  return {
+    body: review.body,
+    rating: review.rating,
+    listing: {
+      connect: {
+        id: review.listingId,
+      },
+    },
+    author: {
+      connect: {
+        id: review.authorId,
+      },
+    },
+  };
+}
+
+export async function seedDevData({ prisma, hashPassword }) {
+  for (const user of DEV_USERS) {
+    const passwordHash = await hashPassword(DEV_PASSWORD);
+    const writeData = userWriteData(user, passwordHash);
+
+    await prisma.user.upsert({
+      where: {
+        id: user.id,
+      },
+      create: {
+        id: user.id,
+        ...writeData,
+      },
+      update: writeData,
+    });
+  }
+
+  for (const listing of DEV_LISTINGS) {
+    const writeData = listingWriteData(listing);
+
+    await prisma.listing.upsert({
+      where: {
+        id: listing.id,
+      },
+      create: {
+        id: listing.id,
+        ...writeData,
+      },
+      update: writeData,
+    });
+  }
+
+  for (const review of DEV_REVIEWS) {
+    const writeData = reviewWriteData(review);
+
+    await prisma.review.upsert({
+      where: {
+        id: review.id,
+      },
+      create: {
+        id: review.id,
+        ...writeData,
+      },
+      update: writeData,
+    });
+  }
+
+  return {
+    users: DEV_USERS.length,
+    listings: DEV_LISTINGS.length,
+    reviews: DEV_REVIEWS.length,
+  };
+}

--- a/apps/web/prisma/seed-data.test.mjs
+++ b/apps/web/prisma/seed-data.test.mjs
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DEV_LISTINGS,
+  DEV_REVIEWS,
+  DEV_USERS,
+  seedDevData,
+} from "./seed-data.mjs";
+
+function createPrismaMock() {
+  return {
+    user: {
+      upsert: vi.fn(),
+    },
+    listing: {
+      upsert: vi.fn(),
+    },
+    review: {
+      upsert: vi.fn(),
+    },
+  };
+}
+
+describe("dev seed data", () => {
+  it("defines multiple local accounts, listings, and reviews", () => {
+    expect(DEV_USERS).toHaveLength(3);
+    expect(DEV_LISTINGS.length).toBeGreaterThanOrEqual(4);
+    expect(DEV_REVIEWS.length).toBeGreaterThanOrEqual(4);
+    expect(DEV_USERS.map((user) => user.email)).toEqual([
+      "owner.one@example.com",
+      "owner.two@example.com",
+      "renter.one@example.com",
+    ]);
+  });
+
+  it("upserts users, listings, and reviews with stable ids", async () => {
+    const prisma = createPrismaMock();
+    const hashPassword = vi.fn(async (password) => `hashed:${password}`);
+
+    await seedDevData({ prisma, hashPassword });
+
+    expect(prisma.user.upsert).toHaveBeenCalledTimes(DEV_USERS.length);
+    expect(prisma.listing.upsert).toHaveBeenCalledTimes(DEV_LISTINGS.length);
+    expect(prisma.review.upsert).toHaveBeenCalledTimes(DEV_REVIEWS.length);
+    expect(hashPassword).toHaveBeenCalledTimes(DEV_USERS.length);
+
+    expect(prisma.user.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: DEV_USERS[0].id },
+        create: expect.objectContaining({
+          id: DEV_USERS[0].id,
+          email: DEV_USERS[0].email,
+          passwordHash: "hashed:Password123!",
+        }),
+        update: expect.objectContaining({
+          email: DEV_USERS[0].email,
+          passwordHash: "hashed:Password123!",
+        }),
+      }),
+    );
+
+    expect(prisma.listing.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: DEV_LISTINGS[0].id },
+        create: expect.objectContaining({
+          id: DEV_LISTINGS[0].id,
+          owner: {
+            connect: {
+              id: DEV_LISTINGS[0].ownerId,
+            },
+          },
+        }),
+        update: expect.objectContaining({
+          owner: {
+            connect: {
+              id: DEV_LISTINGS[0].ownerId,
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(prisma.review.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: DEV_REVIEWS[0].id },
+        create: expect.objectContaining({
+          id: DEV_REVIEWS[0].id,
+          listing: {
+            connect: {
+              id: DEV_REVIEWS[0].listingId,
+            },
+          },
+          author: {
+            connect: {
+              id: DEV_REVIEWS[0].authorId,
+            },
+          },
+        }),
+      }),
+    );
+  });
+});

--- a/apps/web/prisma/seed.mjs
+++ b/apps/web/prisma/seed.mjs
@@ -1,0 +1,24 @@
+import bcrypt from "bcryptjs";
+import { PrismaClient } from "@prisma/client";
+import nextEnv from "@next/env";
+
+import { seedDevData } from "./seed-data.mjs";
+
+const { loadEnvConfig } = nextEnv;
+
+loadEnvConfig(process.cwd());
+
+const prisma = new PrismaClient();
+
+try {
+  const result = await seedDevData({
+    prisma,
+    hashPassword: (password) => bcrypt.hash(password, 10),
+  });
+
+  console.log(
+    `Seeded dev data: ${result.users} users, ${result.listings} listings, ${result.reviews} reviews.`,
+  );
+} finally {
+  await prisma.$disconnect();
+}


### PR DESCRIPTION
## Summary
- Add an idempotent local/dev seed runner for deterministic users, listings, and reviews.
- Add `npm run db:seed` and document the seed workflow plus local test accounts in the web README.
- Add unit coverage for the seed data shape and Prisma upsert behavior.

## Notes
- This is stacked on `feature/rating-reviews` so the PR diff stays focused on seed/dev data. After PR #8 merges, this can be retargeted to `master`.
- Seeded accounts all use `Password123!`: `owner.one@example.com`, `owner.two@example.com`, and `renter.one@example.com`.

## Validation
- `cd apps/web && npm test` — 31 files, 86 tests passed.
- `cd apps/web && npm run lint` — passed.
- `cd apps/web && npm run build` — passed when rerun outside the sandbox after Turbopack hit the known local helper port restriction.
- `cd apps/web && npm run db:seed` — seeded 3 users, 4 listings, and 4 reviews; rerun successfully to confirm idempotence.
- Local smoke check confirmed seeded listings appear on `/listings`.