### PR TITLE
Add user feedback states

### DIFF
--- a/apps/web/src/features/auth/components/login-form.tsx
+++ b/apps/web/src/features/auth/components/login-form.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 
+import { FormFeedback } from "@/features/ui/form-feedback";
+
 type LoginFormProps = {
   callbackUrl: string;
 };
@@ -12,11 +14,13 @@ type LoginFormProps = {
 export function LoginForm({ callbackUrl }: LoginFormProps) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
+    setNotice("Signing in...");
     setIsSubmitting(true);
 
     const formData = new FormData(event.currentTarget);
@@ -30,10 +34,12 @@ export function LoginForm({ callbackUrl }: LoginFormProps) {
     setIsSubmitting(false);
 
     if (result?.error) {
+      setNotice(null);
       setError("Email or password is incorrect.");
       return;
     }
 
+    setNotice("Signed in. Opening your page...");
     router.push(callbackUrl);
     router.refresh();
   }
@@ -41,9 +47,12 @@ export function LoginForm({ callbackUrl }: LoginFormProps) {
   return (
     <form onSubmit={handleSubmit} className="mt-8 grid gap-5">
       {error ? (
-        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {error}
-        </div>
+        <FormFeedback tone="error">{error}</FormFeedback>
+      ) : null}
+      {notice ? (
+        <FormFeedback tone={isSubmitting ? "info" : "success"}>
+          {notice}
+        </FormFeedback>
       ) : null}
 
       <div className="grid gap-2">

--- a/apps/web/src/features/auth/components/register-form.tsx
+++ b/apps/web/src/features/auth/components/register-form.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 
+import { FormFeedback } from "@/features/ui/form-feedback";
+
 type ApiErrorBody = {
   error?: {
     message?: string;
@@ -23,11 +25,13 @@ type RegisterFormProps = {
 export function RegisterForm({ callbackUrl }: RegisterFormProps) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
+    setNotice("Creating account...");
     setIsSubmitting(true);
 
     const formData = new FormData(event.currentTarget);
@@ -47,6 +51,7 @@ export function RegisterForm({ callbackUrl }: RegisterFormProps) {
     });
 
     if (!response.ok) {
+      setNotice(null);
       setError(await readErrorMessage(response));
       setIsSubmitting(false);
       return;
@@ -62,10 +67,12 @@ export function RegisterForm({ callbackUrl }: RegisterFormProps) {
     setIsSubmitting(false);
 
     if (result?.error) {
+      setNotice(null);
       setError("Account created, but sign-in failed. Please sign in manually.");
       return;
     }
 
+    setNotice("Account created. Opening your page...");
     router.push(callbackUrl);
     router.refresh();
   }
@@ -73,9 +80,12 @@ export function RegisterForm({ callbackUrl }: RegisterFormProps) {
   return (
     <form onSubmit={handleSubmit} className="mt-8 grid gap-5">
       {error ? (
-        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {error}
-        </div>
+        <FormFeedback tone="error">{error}</FormFeedback>
+      ) : null}
+      {notice ? (
+        <FormFeedback tone={isSubmitting ? "info" : "success"}>
+          {notice}
+        </FormFeedback>
       ) : null}
 
       <div className="grid gap-2">

--- a/apps/web/src/features/listings/components/listing-archive-button.tsx
+++ b/apps/web/src/features/listings/components/listing-archive-button.tsx
@@ -3,6 +3,8 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+import { FormFeedback } from "@/features/ui/form-feedback";
+
 type ListingArchiveButtonProps = {
   listingId: string;
 };
@@ -10,6 +12,7 @@ type ListingArchiveButtonProps = {
 export function ListingArchiveButton({ listingId }: ListingArchiveButtonProps) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [isArchiving, setIsArchiving] = useState(false);
 
   async function archiveListing() {
@@ -18,6 +21,7 @@ export function ListingArchiveButton({ listingId }: ListingArchiveButtonProps) {
     }
 
     setError(null);
+    setNotice("Archiving listing...");
     setIsArchiving(true);
 
     try {
@@ -26,13 +30,16 @@ export function ListingArchiveButton({ listingId }: ListingArchiveButtonProps) {
       });
 
       if (!response.ok) {
+        setNotice(null);
         setError("Could not archive listing. Please try again.");
         return;
       }
 
+      setNotice("Listing archived.");
       router.push("/listings");
       router.refresh();
     } catch {
+      setNotice(null);
       setError("Could not archive listing. Please try again.");
     } finally {
       setIsArchiving(false);
@@ -49,7 +56,12 @@ export function ListingArchiveButton({ listingId }: ListingArchiveButtonProps) {
       >
         {isArchiving ? "Archiving..." : "Archive"}
       </button>
-      {error ? <p className="text-sm text-red-700">{error}</p> : null}
+      {error ? <FormFeedback tone="error">{error}</FormFeedback> : null}
+      {notice ? (
+        <FormFeedback tone={isArchiving ? "info" : "success"}>
+          {notice}
+        </FormFeedback>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/listings/components/listing-create-form.tsx
+++ b/apps/web/src/features/listings/components/listing-create-form.tsx
@@ -5,6 +5,7 @@ import { useRef, useState, type DragEvent, type FormEvent } from "react";
 
 import { createListingPayloadFromFormData } from "@/features/listings/form-payload";
 import type { ListingCreateInput } from "@/features/listings/schemas";
+import { FormFeedback } from "@/features/ui/form-feedback";
 
 type ApiErrorBody = {
   error?: {
@@ -12,9 +13,9 @@ type ApiErrorBody = {
   };
 };
 
-async function readErrorMessage(response: Response) {
+async function readErrorMessage(response: Response, fallback: string) {
   const body = (await response.json().catch(() => null)) as ApiErrorBody | null;
-  return body?.error?.message ?? "Could not create listing. Please try again.";
+  return body?.error?.message ?? fallback;
 }
 
 type ListingFormValue = {
@@ -74,11 +75,13 @@ export function ListingCreateForm({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [imageUrls, setImageUrls] = useState(listing?.imageUrls ?? []);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isEditMode = mode === "edit";
 
   async function addFiles(files: FileList | File[]) {
     setError(null);
+    setNotice(null);
 
     const imageFiles = Array.from(files).filter((file) =>
       file.type.startsWith("image/"),
@@ -109,6 +112,7 @@ export function ListingCreateForm({
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
+    setNotice(isEditMode ? "Saving listing..." : "Posting listing...");
     setIsSubmitting(true);
 
     const formData = new FormData(event.currentTarget);
@@ -126,7 +130,15 @@ export function ListingCreateForm({
       );
 
       if (!response.ok) {
-        setError(await readErrorMessage(response));
+        setNotice(null);
+        setError(
+          await readErrorMessage(
+            response,
+            isEditMode
+              ? "Could not save listing. Please try again."
+              : "Could not create listing. Please try again.",
+          ),
+        );
         return;
       }
 
@@ -135,10 +147,16 @@ export function ListingCreateForm({
       };
       const listingId = body.data?.listing?.id;
 
+      setNotice(isEditMode ? "Listing saved." : "Listing posted.");
       router.push(listingId ? `/listings/${listingId}` : "/listings");
       router.refresh();
     } catch {
-      setError("Could not create listing. Please try again.");
+      setNotice(null);
+      setError(
+        isEditMode
+          ? "Could not save listing. Please try again."
+          : "Could not create listing. Please try again.",
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -151,9 +169,12 @@ export function ListingCreateForm({
       ))}
 
       {error ? (
-        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {error}
-        </div>
+        <FormFeedback tone="error">{error}</FormFeedback>
+      ) : null}
+      {notice ? (
+        <FormFeedback tone={isSubmitting ? "info" : "success"}>
+          {notice}
+        </FormFeedback>
       ) : null}
 
       <div className="grid gap-2">

--- a/apps/web/src/features/profile/components/profile-account-form.tsx
+++ b/apps/web/src/features/profile/components/profile-account-form.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 
 import type { ProfileUser } from "@/features/profile/queries";
+import { FormFeedback } from "@/features/ui/form-feedback";
 
 type ApiErrorBody = {
   error?: {
@@ -30,7 +31,7 @@ export function ProfileAccountForm({ user }: { user: ProfileUser }) {
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
-    setNotice(null);
+    setNotice("Saving profile...");
     setIsSubmitting(true);
 
     const formData = new FormData(event.currentTarget);
@@ -49,6 +50,7 @@ export function ProfileAccountForm({ user }: { user: ProfileUser }) {
       });
 
       if (!response.ok) {
+        setNotice(null);
         setError(await readErrorMessage(response));
         return;
       }
@@ -56,6 +58,7 @@ export function ProfileAccountForm({ user }: { user: ProfileUser }) {
       setNotice("Profile updated.");
       router.refresh();
     } catch {
+      setNotice(null);
       setError("Could not update your profile. Please try again.");
     } finally {
       setIsSubmitting(false);
@@ -68,14 +71,12 @@ export function ProfileAccountForm({ user }: { user: ProfileUser }) {
       className="mt-4 grid gap-4 rounded-md border border-zinc-200 p-4"
     >
       {error ? (
-        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {error}
-        </div>
+        <FormFeedback tone="error">{error}</FormFeedback>
       ) : null}
       {notice ? (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+        <FormFeedback tone={isSubmitting ? "info" : "success"}>
           {notice}
-        </div>
+        </FormFeedback>
       ) : null}
 
       <ProfileAccountFields user={user} />

--- a/apps/web/src/features/reviews/components/review-section.tsx
+++ b/apps/web/src/features/reviews/components/review-section.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 
 import type { ReviewApiResponse } from "@/features/reviews/schemas";
+import { FormFeedback } from "@/features/ui/form-feedback";
 
 type ReviewSectionProps = {
   listingId: string;
@@ -35,12 +36,14 @@ export function ReviewSection({
   const [reviews, setReviews] = useState(initialReviews);
   const [editingReviewId, setEditingReviewId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isSignedIn = Boolean(currentUserId);
 
   async function createReview(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
+    setNotice("Posting review...");
     setIsSubmitting(true);
 
     const form = event.currentTarget;
@@ -60,6 +63,7 @@ export function ReviewSection({
       });
 
       if (!response.ok) {
+        setNotice(null);
         setError(await readErrorMessage(response, "Could not add review."));
         return;
       }
@@ -73,8 +77,10 @@ export function ReviewSection({
       }
 
       form.reset();
+      setNotice("Review posted.");
       router.refresh();
     } catch {
+      setNotice(null);
       setError("Could not add review.");
     } finally {
       setIsSubmitting(false);
@@ -84,6 +90,7 @@ export function ReviewSection({
   async function updateReview(event: FormEvent<HTMLFormElement>, reviewId: string) {
     event.preventDefault();
     setError(null);
+    setNotice("Saving review...");
     setIsSubmitting(true);
 
     const formData = new FormData(event.currentTarget);
@@ -102,6 +109,7 @@ export function ReviewSection({
       });
 
       if (!response.ok) {
+        setNotice(null);
         setError(await readErrorMessage(response, "Could not update review."));
         return;
       }
@@ -119,8 +127,10 @@ export function ReviewSection({
       }
 
       setEditingReviewId(null);
+      setNotice("Review saved.");
       router.refresh();
     } catch {
+      setNotice(null);
       setError("Could not update review.");
     } finally {
       setIsSubmitting(false);
@@ -133,6 +143,7 @@ export function ReviewSection({
     }
 
     setError(null);
+    setNotice("Deleting review...");
     setIsSubmitting(true);
 
     try {
@@ -141,13 +152,16 @@ export function ReviewSection({
       });
 
       if (!response.ok) {
+        setNotice(null);
         setError(await readErrorMessage(response, "Could not delete review."));
         return;
       }
 
       setReviews((current) => current.filter((review) => review.id !== reviewId));
+      setNotice("Review deleted.");
       router.refresh();
     } catch {
+      setNotice(null);
       setError("Could not delete review.");
     } finally {
       setIsSubmitting(false);
@@ -170,8 +184,15 @@ export function ReviewSection({
       </div>
 
       {error ? (
-        <div className="mt-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {error}
+        <div className="mt-4">
+          <FormFeedback tone="error">{error}</FormFeedback>
+        </div>
+      ) : null}
+      {notice ? (
+        <div className="mt-4">
+          <FormFeedback tone={isSubmitting ? "info" : "success"}>
+            {notice}
+          </FormFeedback>
         </div>
       ) : null}
 

--- a/apps/web/src/features/ui/form-feedback.test.tsx
+++ b/apps/web/src/features/ui/form-feedback.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { FormFeedback } from "@/features/ui/form-feedback";
+
+describe("FormFeedback", () => {
+  it("renders errors as alerts", () => {
+    const feedback = FormFeedback({
+      tone: "error",
+      children: "Could not save.",
+    });
+
+    expect(feedback.props.role).toBe("alert");
+    expect(feedback.props.children).toBe("Could not save.");
+    expect(feedback.props.className).toContain("border-red-200");
+  });
+
+  it("renders progress and success as live status messages", () => {
+    const feedback = FormFeedback({
+      tone: "success",
+      children: "Saved.",
+    });
+
+    expect(feedback.props.role).toBe("status");
+    expect(feedback.props["aria-live"]).toBe("polite");
+    expect(feedback.props.children).toBe("Saved.");
+    expect(feedback.props.className).toContain("border-emerald-200");
+  });
+});

--- a/apps/web/src/features/ui/form-feedback.tsx
+++ b/apps/web/src/features/ui/form-feedback.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+type FormFeedbackProps = {
+  tone: "error" | "info" | "success";
+  children: ReactNode;
+};
+
+const toneClassNames = {
+  error: "border-red-200 bg-red-50 text-red-700",
+  info: "border-sky-200 bg-sky-50 text-sky-800",
+  success: "border-emerald-200 bg-emerald-50 text-emerald-800",
+};
+
+export function FormFeedback({ tone, children }: FormFeedbackProps) {
+  const isError = tone === "error";
+
+  return (
+    <div
+      role={isError ? "alert" : "status"}
+      aria-live={isError ? "assertive" : "polite"}
+      className={`rounded-md border px-4 py-3 text-sm ${toneClassNames[tone]}`}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a shared accessible `FormFeedback` component for form alerts/status messages.
- Wire consistent progress, success, and error states into auth, profile, listing, archive, and review actions.
- Tighten listing create/edit copy so failures and progress messages match the current action.

## Validation
- `cd apps/web && npm test` — 32 files, 88 tests passed.
- `cd apps/web && npm run lint` — passed.
- `cd apps/web && npm run build` — passed when rerun outside the sandbox after Turbopack hit the known local helper port restriction.
- User confirmed the feedback states in the local UI before packaging.