### PR TITLE
Add saved listings

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -29,28 +29,29 @@ enum PetPolicy {
 }
 
 model User {
-  id           String    @id @default(auto()) @map("_id") @db.ObjectId
-  email        String    @unique
-  name         String?
-  image        String?
-  contactEmail String?
-  contactPhone String?
-  passwordHash String?
-  listings     Listing[]
-  reviews      Review[]
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
+  id            String         @id @default(auto()) @map("_id") @db.ObjectId
+  email         String         @unique
+  name          String?
+  image         String?
+  contactEmail  String?
+  contactPhone  String?
+  passwordHash  String?
+  listings      Listing[]
+  reviews       Review[]
+  savedListings SavedListing[]
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
 }
 
 model Listing {
-  id                String        @id @default(auto()) @map("_id") @db.ObjectId
+  id                String         @id @default(auto()) @map("_id") @db.ObjectId
   title             String
   type              ListingType
-  status            ListingStatus @default(ACTIVE)
+  status            ListingStatus  @default(ACTIVE)
   description       String
   rent              Int
   deposit           Int?
-  utilitiesIncluded Boolean       @default(false)
+  utilitiesIncluded Boolean        @default(false)
   availableFrom     DateTime?
   leaseDuration     String?
   address           String?
@@ -59,14 +60,15 @@ model Listing {
   contactPhone      String?
   bedrooms          Int?
   bathrooms         Float?
-  petPolicy         PetPolicy     @default(UNKNOWN)
+  petPolicy         PetPolicy      @default(UNKNOWN)
   amenities         String[]
   imageUrls         String[]
-  ownerId           String?       @db.ObjectId
-  owner             User?         @relation(fields: [ownerId], references: [id])
+  ownerId           String?        @db.ObjectId
+  owner             User?          @relation(fields: [ownerId], references: [id])
   reviews           Review[]
-  createdAt         DateTime      @default(now())
-  updatedAt         DateTime      @updatedAt
+  savedBy           SavedListing[]
+  createdAt         DateTime       @default(now())
+  updatedAt         DateTime       @updatedAt
 
   @@index([status])
   @@index([type])
@@ -79,6 +81,19 @@ model Listing {
   @@index([status, bathrooms])
   @@index([status, availableFrom])
   @@index([status, petPolicy])
+}
+
+model SavedListing {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  userId    String   @db.ObjectId
+  user      User     @relation(fields: [userId], references: [id])
+  listingId String   @db.ObjectId
+  listing   Listing  @relation(fields: [listingId], references: [id])
+  createdAt DateTime @default(now())
+
+  @@unique([userId, listingId])
+  @@index([userId, createdAt])
+  @@index([listingId])
 }
 
 model Review {

--- a/apps/web/prisma/seed-data.mjs
+++ b/apps/web/prisma/seed-data.mjs
@@ -150,6 +150,19 @@ export const DEV_REVIEWS = [
   },
 ];
 
+export const DEV_SAVED_LISTINGS = [
+  {
+    id: "66a000000000000000000401",
+    userId: DEV_USERS[2].id,
+    listingId: DEV_LISTINGS[0].id,
+  },
+  {
+    id: "66a000000000000000000402",
+    userId: DEV_USERS[2].id,
+    listingId: DEV_LISTINGS[2].id,
+  },
+];
+
 function userWriteData(user, passwordHash) {
   return {
     email: user.email,
@@ -205,6 +218,21 @@ function reviewWriteData(review) {
   };
 }
 
+function savedListingWriteData(savedListing) {
+  return {
+    user: {
+      connect: {
+        id: savedListing.userId,
+      },
+    },
+    listing: {
+      connect: {
+        id: savedListing.listingId,
+      },
+    },
+  };
+}
+
 export async function seedDevData({ prisma, hashPassword }) {
   for (const user of DEV_USERS) {
     const passwordHash = await hashPassword(DEV_PASSWORD);
@@ -252,9 +280,25 @@ export async function seedDevData({ prisma, hashPassword }) {
     });
   }
 
+  for (const savedListing of DEV_SAVED_LISTINGS) {
+    const writeData = savedListingWriteData(savedListing);
+
+    await prisma.savedListing.upsert({
+      where: {
+        id: savedListing.id,
+      },
+      create: {
+        id: savedListing.id,
+        ...writeData,
+      },
+      update: writeData,
+    });
+  }
+
   return {
     users: DEV_USERS.length,
     listings: DEV_LISTINGS.length,
     reviews: DEV_REVIEWS.length,
+    savedListings: DEV_SAVED_LISTINGS.length,
   };
 }

--- a/apps/web/prisma/seed-data.test.mjs
+++ b/apps/web/prisma/seed-data.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   DEV_LISTINGS,
   DEV_REVIEWS,
+  DEV_SAVED_LISTINGS,
   DEV_USERS,
   seedDevData,
 } from "./seed-data.mjs";
@@ -18,6 +19,9 @@ function createPrismaMock() {
     review: {
       upsert: vi.fn(),
     },
+    savedListing: {
+      upsert: vi.fn(),
+    },
   };
 }
 
@@ -26,6 +30,7 @@ describe("dev seed data", () => {
     expect(DEV_USERS).toHaveLength(3);
     expect(DEV_LISTINGS.length).toBeGreaterThanOrEqual(4);
     expect(DEV_REVIEWS.length).toBeGreaterThanOrEqual(4);
+    expect(DEV_SAVED_LISTINGS.length).toBeGreaterThanOrEqual(2);
     expect(DEV_USERS.map((user) => user.email)).toEqual([
       "owner.one@example.com",
       "owner.two@example.com",
@@ -42,6 +47,9 @@ describe("dev seed data", () => {
     expect(prisma.user.upsert).toHaveBeenCalledTimes(DEV_USERS.length);
     expect(prisma.listing.upsert).toHaveBeenCalledTimes(DEV_LISTINGS.length);
     expect(prisma.review.upsert).toHaveBeenCalledTimes(DEV_REVIEWS.length);
+    expect(prisma.savedListing.upsert).toHaveBeenCalledTimes(
+      DEV_SAVED_LISTINGS.length,
+    );
     expect(hashPassword).toHaveBeenCalledTimes(DEV_USERS.length);
 
     expect(prisma.user.upsert).toHaveBeenCalledWith(
@@ -93,6 +101,25 @@ describe("dev seed data", () => {
           author: {
             connect: {
               id: DEV_REVIEWS[0].authorId,
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(prisma.savedListing.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: DEV_SAVED_LISTINGS[0].id },
+        create: expect.objectContaining({
+          id: DEV_SAVED_LISTINGS[0].id,
+          user: {
+            connect: {
+              id: DEV_SAVED_LISTINGS[0].userId,
+            },
+          },
+          listing: {
+            connect: {
+              id: DEV_SAVED_LISTINGS[0].listingId,
             },
           },
         }),

--- a/apps/web/prisma/seed.mjs
+++ b/apps/web/prisma/seed.mjs
@@ -17,7 +17,7 @@ try {
   });
 
   console.log(
-    `Seeded dev data: ${result.users} users, ${result.listings} listings, ${result.reviews} reviews.`,
+    `Seeded dev data: ${result.users} users, ${result.listings} listings, ${result.reviews} reviews, ${result.savedListings} saved listings.`,
   );
 } finally {
   await prisma.$disconnect();

--- a/apps/web/src/app/api/listings/[id]/save/route.test.ts
+++ b/apps/web/src/app/api/listings/[id]/save/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DELETE, POST } from "@/app/api/listings/[id]/save/route";
+import {
+  saveListing,
+  unsaveListing,
+} from "@/features/saved-listings/mutations";
+import { authRequired } from "@/server/api/errors";
+import { requireCurrentUser } from "@/server/auth/current-user";
+
+vi.mock("@/features/saved-listings/mutations", () => ({
+  saveListing: vi.fn(),
+  unsaveListing: vi.fn(),
+}));
+
+vi.mock("@/server/auth/current-user", () => ({
+  requireCurrentUser: vi.fn(),
+}));
+
+const userId = "507f1f77bcf86cd799439099";
+const listingId = "507f1f77bcf86cd799439011";
+
+describe("listing save APIs", () => {
+  beforeEach(() => {
+    vi.mocked(saveListing).mockReset();
+    vi.mocked(unsaveListing).mockReset();
+    vi.mocked(requireCurrentUser).mockResolvedValue({
+      id: userId,
+      email: "renter@example.com",
+      name: "Renter",
+    });
+  });
+
+  it("saves a listing for the signed-in user", async () => {
+    const response = await POST(
+      new Request(`http://localhost:3000/api/listings/${listingId}/save`, {
+        method: "POST",
+      }),
+      { params: Promise.resolve({ id: listingId }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        saved: true,
+      },
+    });
+    expect(saveListing).toHaveBeenCalledWith(userId, listingId);
+  });
+
+  it("removes a saved listing for the signed-in user", async () => {
+    const response = await DELETE(
+      new Request(`http://localhost:3000/api/listings/${listingId}/save`, {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ id: listingId }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        saved: false,
+      },
+    });
+    expect(unsaveListing).toHaveBeenCalledWith(userId, listingId);
+  });
+
+  it("requires a signed-in user before saving", async () => {
+    vi.mocked(requireCurrentUser).mockRejectedValue(authRequired());
+
+    const response = await POST(
+      new Request(`http://localhost:3000/api/listings/${listingId}/save`, {
+        method: "POST",
+      }),
+      { params: Promise.resolve({ id: listingId }) },
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "AUTH_REQUIRED",
+      },
+    });
+    expect(saveListing).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/listings/[id]/save/route.ts
+++ b/apps/web/src/app/api/listings/[id]/save/route.ts
@@ -1,0 +1,40 @@
+import { listingParamsSchema } from "@/features/listings/schemas";
+import {
+  saveListing,
+  unsaveListing,
+} from "@/features/saved-listings/mutations";
+import { savedListingResponseSchema } from "@/features/saved-listings/schemas";
+import { apiData, throwIfInvalid, withApiErrorHandling } from "@/server/api/responses";
+import { requireCurrentUser } from "@/server/auth/current-user";
+
+export const dynamic = "force-dynamic";
+
+type ListingSaveRouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function POST(_request: Request, context: ListingSaveRouteContext) {
+  return withApiErrorHandling(async () => {
+    const currentUser = await requireCurrentUser();
+    const params = throwIfInvalid(
+      listingParamsSchema.safeParse(await context.params),
+    );
+
+    await saveListing(currentUser.id, params.id);
+
+    return apiData(savedListingResponseSchema.parse({ saved: true }));
+  });
+}
+
+export async function DELETE(_request: Request, context: ListingSaveRouteContext) {
+  return withApiErrorHandling(async () => {
+    const currentUser = await requireCurrentUser();
+    const params = throwIfInvalid(
+      listingParamsSchema.safeParse(await context.params),
+    );
+
+    await unsaveListing(currentUser.id, params.id);
+
+    return apiData(savedListingResponseSchema.parse({ saved: false }));
+  });
+}

--- a/apps/web/src/app/listings/[id]/page.test.tsx
+++ b/apps/web/src/app/listings/[id]/page.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import ListingDetailPage from "@/app/listings/[id]/page";
 import { getListingById } from "@/features/listings/queries";
 import { getReviewsForListing } from "@/features/reviews/mutations";
+import { getSavedListingIdsByUser } from "@/features/saved-listings/queries";
 import { auth } from "@/server/auth/auth";
 
 vi.mock("@/features/listings/queries", () => ({
@@ -11,6 +12,10 @@ vi.mock("@/features/listings/queries", () => ({
 
 vi.mock("@/features/reviews/mutations", () => ({
   getReviewsForListing: vi.fn(),
+}));
+
+vi.mock("@/features/saved-listings/queries", () => ({
+  getSavedListingIdsByUser: vi.fn(),
 }));
 
 vi.mock("@/server/auth/auth", () => ({
@@ -69,9 +74,34 @@ function hasHref(node: unknown, href: string): boolean {
   return hasHref(children, href);
 }
 
+function includesText(
+  node: unknown,
+  text: string,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node).includes(text);
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  if (seen.has(node)) {
+    return false;
+  }
+  seen.add(node);
+
+  const values = Object.values(node);
+
+  return values.some((value) => includesText(value, text, seen));
+}
+
 describe("ListingDetailPage", () => {
   beforeEach(() => {
+    vi.mocked(getSavedListingIdsByUser).mockReset();
     vi.mocked(getReviewsForListing).mockResolvedValue([]);
+    vi.mocked(getSavedListingIdsByUser).mockResolvedValue([]);
   });
 
   it("shows edit controls for the listing owner", async () => {
@@ -110,10 +140,11 @@ describe("ListingDetailPage", () => {
       params: Promise.resolve({ id: listing.id }),
     });
 
-    expect(JSON.stringify(page)).toContain(
+    expect(includesText(
+      page,
       "The room details were accurate and the poster replied quickly.",
-    );
-    expect(JSON.stringify(page)).toContain('"rating":5');
+    )).toBe(true);
+    expect(includesText(page, "Renter One")).toBe(true);
     expect(getReviewsForListing).toHaveBeenCalledWith(listing.id);
   });
 });

--- a/apps/web/src/app/listings/[id]/page.tsx
+++ b/apps/web/src/app/listings/[id]/page.tsx
@@ -4,6 +4,8 @@ import { ListingImageGallery } from "@/features/listings/components/listing-imag
 import { ReviewSection } from "@/features/reviews/components/review-section";
 import { getReviewsForListing } from "@/features/reviews/mutations";
 import { serializeReview } from "@/features/reviews/schemas";
+import { SavedListingButton } from "@/features/saved-listings/components/saved-listing-button";
+import { getSavedListingIdsByUser } from "@/features/saved-listings/queries";
 import { auth } from "@/server/auth/auth";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -29,6 +31,10 @@ export default async function ListingDetailPage({
   }
 
   const isOwner = Boolean(session?.user?.id && session.user.id === listing.ownerId);
+  const savedListingIds = session?.user?.id
+    ? await getSavedListingIdsByUser(session.user.id)
+    : [];
+  const isSaved = savedListingIds.includes(listing.id);
   const hasContactInfo = Boolean(listing.contactEmail || listing.contactPhone);
   const details = [
     ["Deposit", listing.deposit === null ? "Not listed" : `$${listing.deposit}`],
@@ -67,7 +73,16 @@ export default async function ListingDetailPage({
             </Link>
             <ListingArchiveButton listingId={listing.id} />
           </div>
-        ) : null}
+        ) : session?.user?.id ? (
+          <SavedListingButton listingId={listing.id} initialSaved={isSaved} />
+        ) : (
+          <Link
+            href={`/login?callbackUrl=${encodeURIComponent(`/listings/${listing.id}`)}`}
+            className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-950 hover:bg-zinc-100"
+          >
+            Sign in to save
+          </Link>
+        )}
       </div>
       <h1 className="text-4xl font-semibold text-zinc-950">{listing.title}</h1>
       <p className="mt-4 text-xl font-medium text-zinc-950">

--- a/apps/web/src/app/listings/page.test.tsx
+++ b/apps/web/src/app/listings/page.test.tsx
@@ -2,9 +2,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ListingsPage from "@/app/listings/page";
 import { getActiveListings } from "@/features/listings/queries";
+import { getSavedListingIdsByUser } from "@/features/saved-listings/queries";
+import { auth } from "@/server/auth/auth";
 
 vi.mock("@/features/listings/queries", () => ({
   getActiveListings: vi.fn(),
+}));
+
+vi.mock("@/features/saved-listings/queries", () => ({
+  getSavedListingIdsByUser: vi.fn(),
+}));
+
+vi.mock("@/server/auth/auth", () => ({
+  auth: vi.fn(),
 }));
 
 function expandNode(node: unknown): unknown {
@@ -76,6 +86,8 @@ function hasInputDefault(node: unknown, name: string, defaultValue: string): boo
 describe("ListingsPage", () => {
   beforeEach(() => {
     vi.mocked(getActiveListings).mockReset();
+    vi.mocked(getSavedListingIdsByUser).mockReset();
+    vi.mocked(auth).mockReset();
   });
 
   it("uses URL filters for active listing discovery", async () => {
@@ -186,5 +198,55 @@ describe("ListingsPage", () => {
     expect(includesText(page, "Apply filters")).toBe(true);
     expect(includesText(page, "Clear")).toBe(true);
     expect(includesText(page, "Post listing")).toBe(false);
+  });
+
+  it("marks saved listings for signed-in users", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "507f1f77bcf86cd799439099",
+        email: "renter@example.com",
+        name: "Renter",
+      },
+      expires: "2026-06-01T00:00:00.000Z",
+    });
+    vi.mocked(getActiveListings).mockResolvedValue([
+      {
+        id: "507f1f77bcf86cd799439011",
+        title: "Saved room near campus",
+        type: "ROOM",
+        status: "ACTIVE",
+        description: "Walkable room with utilities included.",
+        rent: 650,
+        deposit: null,
+        utilitiesIncluded: true,
+        availableFrom: null,
+        leaseDuration: "12 months",
+        address: null,
+        distanceToCampus: "0.5 miles",
+        contactEmail: null,
+        contactPhone: null,
+        bedrooms: 1,
+        bathrooms: 1,
+        petPolicy: "UNKNOWN",
+        amenities: [],
+        imageUrls: [],
+        ownerId: null,
+        createdAt: new Date("2026-05-18T12:00:00.000Z"),
+        updatedAt: new Date("2026-05-19T12:00:00.000Z"),
+      },
+    ]);
+    vi.mocked(getSavedListingIdsByUser).mockResolvedValue([
+      "507f1f77bcf86cd799439011",
+    ]);
+
+    const page = await ListingsPage({
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(getSavedListingIdsByUser).toHaveBeenCalledWith(
+      "507f1f77bcf86cd799439099",
+    );
+    expect(includesText(page, "Saved room near campus")).toBe(true);
+    expect(includesText(page, "Saved")).toBe(true);
   });
 });

--- a/apps/web/src/app/listings/page.tsx
+++ b/apps/web/src/app/listings/page.tsx
@@ -12,6 +12,8 @@ import {
   listingQuerySchema,
   type ListingQueryInput,
 } from "@/features/listings/schemas";
+import { getSavedListingIdsByUser } from "@/features/saved-listings/queries";
+import { auth } from "@/server/auth/auth";
 
 export const dynamic = "force-dynamic";
 
@@ -34,7 +36,14 @@ async function parseListingFilters(
 
 export default async function ListingsPage({ searchParams }: ListingsPageProps) {
   const filters = await parseListingFilters(searchParams);
-  const listings = await getActiveListings(filters);
+  const [listings, session] = await Promise.all([
+    getActiveListings(filters),
+    auth(),
+  ]);
+  const savedListingIds = session?.user?.id
+    ? await getSavedListingIdsByUser(session.user.id)
+    : [];
+  const savedListingIdSet = new Set(savedListingIds);
 
   return (
     <main className="mx-auto max-w-6xl px-6 py-10">
@@ -69,7 +78,12 @@ export default async function ListingsPage({ searchParams }: ListingsPageProps) 
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {listings.map((listing) => (
-            <ListingCard key={listing.id} listing={listing} />
+            <ListingCard
+              key={listing.id}
+              listing={listing}
+              isSaved={savedListingIdSet.has(listing.id)}
+              showSaveAction={Boolean(session?.user?.id)}
+            />
           ))}
         </div>
       )}

--- a/apps/web/src/app/profile/page.test.tsx
+++ b/apps/web/src/app/profile/page.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import ProfilePage from "@/app/profile/page";
 import { getListingsByOwner } from "@/features/listings/queries";
 import { getProfileUser } from "@/features/profile/queries";
+import { getSavedListingsByUser } from "@/features/saved-listings/queries";
 import { auth } from "@/server/auth/auth";
 
 vi.mock("@/features/listings/queries", () => ({
@@ -11,6 +12,10 @@ vi.mock("@/features/listings/queries", () => ({
 
 vi.mock("@/features/profile/queries", () => ({
   getProfileUser: vi.fn(),
+}));
+
+vi.mock("@/features/saved-listings/queries", () => ({
+  getSavedListingsByUser: vi.fn(),
 }));
 
 vi.mock("@/server/auth/auth", () => ({
@@ -43,6 +48,7 @@ const ownedListings = [
     contactPhone: null,
     bedrooms: 1,
     bathrooms: 1,
+    petPolicy: "UNKNOWN" as const,
     amenities: ["Laundry"],
     imageUrls: [],
     ownerId,
@@ -66,6 +72,7 @@ const ownedListings = [
     contactPhone: null,
     bedrooms: 0,
     bathrooms: 1,
+    petPolicy: "UNKNOWN" as const,
     amenities: [],
     imageUrls: [],
     ownerId,
@@ -74,7 +81,38 @@ const ownedListings = [
   },
 ];
 
-function includesText(node: unknown, text: string): boolean {
+const savedListings = [
+  {
+    id: "507f1f77bcf86cd799439013",
+    title: "Saved studio near campus",
+    type: "APARTMENT" as const,
+    status: "ACTIVE" as const,
+    description: "Bright studio close to bus lines.",
+    rent: 850,
+    deposit: 850,
+    utilitiesIncluded: false,
+    availableFrom: null,
+    leaseDuration: null,
+    address: null,
+    distanceToCampus: null,
+    contactEmail: null,
+    contactPhone: null,
+    bedrooms: 0,
+    bathrooms: 1,
+    petPolicy: "UNKNOWN" as const,
+    amenities: [],
+    imageUrls: [],
+    ownerId: "507f1f77bcf86cd799439088",
+    createdAt: new Date("2026-05-18T12:00:00.000Z"),
+    updatedAt: new Date("2026-05-20T12:00:00.000Z"),
+  },
+];
+
+function includesText(
+  node: unknown,
+  text: string,
+  seen = new WeakSet<object>(),
+): boolean {
   if (typeof node === "string" || typeof node === "number") {
     return String(node).includes(text);
   }
@@ -83,14 +121,24 @@ function includesText(node: unknown, text: string): boolean {
     return false;
   }
 
+  if (seen.has(node)) {
+    return false;
+  }
+  seen.add(node);
+
   const element = node as { props?: { children?: unknown } };
-  const children = element.props?.children;
+  const props = element.props;
+  const children = props?.children;
 
   if (Array.isArray(children)) {
-    return children.some((child) => includesText(child, text));
+    return children.some((child) => includesText(child, text, seen));
   }
 
-  return includesText(children, text);
+  if (includesText(children, text, seen)) {
+    return true;
+  }
+
+  return Object.values(props ?? {}).some((value) => includesText(value, text, seen));
 }
 
 function hasHref(node: unknown, href: string): boolean {
@@ -115,6 +163,37 @@ function hasHref(node: unknown, href: string): boolean {
   return hasHref(children, href);
 }
 
+function hasListingPropTitle(
+  node: unknown,
+  title: string,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (Array.isArray(node)) {
+    return node.some((child) => hasListingPropTitle(child, title, seen));
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  if (seen.has(node)) {
+    return false;
+  }
+  seen.add(node);
+
+  const element = node as {
+    props?: { listing?: { title?: unknown }; children?: unknown };
+  };
+
+  if (element.props?.listing?.title === title) {
+    return true;
+  }
+
+  return Object.values(element.props ?? {}).some((value) =>
+    hasListingPropTitle(value, title, seen),
+  );
+}
+
 describe("ProfilePage", () => {
   it("redirects signed-out users to login with a callback", async () => {
     vi.mocked(auth).mockResolvedValue(null);
@@ -125,6 +204,7 @@ describe("ProfilePage", () => {
 
     expect(getProfileUser).not.toHaveBeenCalled();
     expect(getListingsByOwner).not.toHaveBeenCalled();
+    expect(getSavedListingsByUser).not.toHaveBeenCalled();
   });
 
   it("renders the signed-in user's profile and all owned listing statuses", async () => {
@@ -145,11 +225,13 @@ describe("ProfilePage", () => {
       createdAt: new Date("2026-05-01T12:00:00.000Z"),
     });
     vi.mocked(getListingsByOwner).mockResolvedValue(ownedListings);
+    vi.mocked(getSavedListingsByUser).mockResolvedValue(savedListings);
 
     const page = await ProfilePage();
 
     expect(getProfileUser).toHaveBeenCalledWith(ownerId);
     expect(getListingsByOwner).toHaveBeenCalledWith(ownerId);
+    expect(getSavedListingsByUser).toHaveBeenCalledWith(ownerId);
     expect(includesText(page, "Owner Name")).toBe(true);
     expect(includesText(page, "owner@example.com")).toBe(true);
     expect(includesText(page, "Account basics")).toBe(true);
@@ -157,6 +239,8 @@ describe("ProfilePage", () => {
     expect(includesText(page, "Active room near SCSU")).toBe(true);
     expect(includesText(page, "Archived studio")).toBe(true);
     expect(includesText(page, "ARCHIVED")).toBe(true);
+    expect(includesText(page, "Saved listings")).toBe(true);
+    expect(hasListingPropTitle(page, "Saved studio near campus")).toBe(true);
     expect(hasHref(page, "/listings/507f1f77bcf86cd799439011/edit")).toBe(true);
   });
 });

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -3,9 +3,11 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { ListingArchiveButton } from "@/features/listings/components/listing-archive-button";
+import { ListingCard } from "@/features/listings/components/listing-card";
 import { getListingsByOwner } from "@/features/listings/queries";
 import { ProfileAccountForm } from "@/features/profile/components/profile-account-form";
 import { getProfileUser } from "@/features/profile/queries";
+import { getSavedListingsByUser } from "@/features/saved-listings/queries";
 import { auth } from "@/server/auth/auth";
 
 export const dynamic = "force-dynamic";
@@ -68,9 +70,10 @@ export default async function ProfilePage() {
     redirect("/login?callbackUrl=%2Fprofile");
   }
 
-  const [profileUser, listings] = await Promise.all([
+  const [profileUser, listings, savedListings] = await Promise.all([
     getProfileUser(session.user.id),
     getListingsByOwner(session.user.id),
+    getSavedListingsByUser(session.user.id),
   ]);
   const displayName = profileUser?.name ?? session.user.name ?? "Renter";
   const email = profileUser?.email ?? session.user.email;
@@ -149,6 +152,51 @@ export default async function ProfilePage() {
         ) : (
           <div className="mt-6 grid gap-3">
             {listings.map(renderProfileListingRow)}
+          </div>
+        )}
+      </section>
+
+      <section className="mt-8">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h2 className="text-2xl font-semibold text-zinc-950">
+              Saved listings
+            </h2>
+            <p className="mt-1 text-sm text-zinc-600">
+              Keep track of apartments and rooms you want to revisit.
+            </p>
+          </div>
+          <p className="text-sm font-medium text-zinc-500">
+            {savedListings.length} saved
+          </p>
+        </div>
+
+        {savedListings.length === 0 ? (
+          <div className="mt-6 rounded-md border border-dashed border-zinc-300 px-6 py-10 text-center">
+            <h3 className="text-lg font-semibold text-zinc-950">
+              No saved listings yet
+            </h3>
+            <p className="mx-auto mt-2 max-w-md text-sm text-zinc-600">
+              Save listings from the browse page or listing details when you
+              want to compare them later.
+            </p>
+            <Link
+              href="/listings"
+              className="mt-5 inline-flex rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+            >
+              Browse listings
+            </Link>
+          </div>
+        ) : (
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {savedListings.map((listing) => (
+              <ListingCard
+                key={listing.id}
+                listing={listing}
+                isSaved
+                showSaveAction
+              />
+            ))}
           </div>
         )}
       </section>

--- a/apps/web/src/features/listings/components/listing-card.tsx
+++ b/apps/web/src/features/listings/components/listing-card.tsx
@@ -1,26 +1,38 @@
 import type { Listing } from "@prisma/client";
 import Link from "next/link";
 
+import { SavedListingButton } from "@/features/saved-listings/components/saved-listing-button";
+
 type ListingCardProps = {
   listing: Listing;
+  isSaved?: boolean;
+  showSaveAction?: boolean;
 };
 
-export function ListingCard({ listing }: ListingCardProps) {
+export function ListingCard({
+  listing,
+  isSaved = false,
+  showSaveAction = false,
+}: ListingCardProps) {
   return (
-    <Link
-      href={`/listings/${listing.id}`}
-      className="rounded-md border border-zinc-200 p-4 transition hover:border-zinc-400"
-    >
-      <div className="text-xs font-medium uppercase text-emerald-700">
-        {listing.type}
-      </div>
-      <h2 className="mt-2 text-lg font-semibold text-zinc-950">
-        {listing.title}
-      </h2>
-      <p className="mt-2 line-clamp-2 text-sm text-zinc-600">
-        {listing.description}
-      </p>
-      <p className="mt-4 font-medium text-zinc-950">${listing.rent}/month</p>
-    </Link>
+    <article className="grid gap-4 rounded-md border border-zinc-200 p-4 transition hover:border-zinc-400">
+      <Link href={`/listings/${listing.id}`} className="block">
+        <div className="text-xs font-medium uppercase text-emerald-700">
+          {listing.type}
+        </div>
+        <h2 className="mt-2 text-lg font-semibold text-zinc-950">
+          {listing.title}
+        </h2>
+        <p className="mt-2 line-clamp-2 text-sm text-zinc-600">
+          {listing.description}
+        </p>
+        <p className="mt-4 font-medium text-zinc-950">${listing.rent}/month</p>
+      </Link>
+      {showSaveAction ? (
+        <div className="flex justify-end">
+          <SavedListingButton listingId={listing.id} initialSaved={isSaved} />
+        </div>
+      ) : null}
+    </article>
   );
 }

--- a/apps/web/src/features/saved-listings/components/saved-listing-button.tsx
+++ b/apps/web/src/features/saved-listings/components/saved-listing-button.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { FormFeedback } from "@/features/ui/form-feedback";
+
+type SavedListingButtonProps = {
+  listingId: string;
+  initialSaved: boolean;
+};
+
+export function SavedListingButton({
+  listingId,
+  initialSaved,
+}: SavedListingButtonProps) {
+  const router = useRouter();
+  const [isSaved, setIsSaved] = useState(initialSaved);
+  const [error, setError] = useState<string | null>(null);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  async function handleClick() {
+    setError(null);
+    setIsUpdating(true);
+
+    const nextSaved = !isSaved;
+    let response: Response;
+
+    try {
+      response = await fetch(`/api/listings/${listingId}/save`, {
+        method: nextSaved ? "POST" : "DELETE",
+      });
+    } catch {
+      setIsUpdating(false);
+      setError("Could not update saved listing.");
+      return;
+    }
+
+    if (!response.ok) {
+      setIsUpdating(false);
+      setError("Could not update saved listing.");
+      return;
+    }
+
+    setIsSaved(nextSaved);
+    setIsUpdating(false);
+    startTransition(() => {
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="grid gap-2">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isUpdating || isPending}
+        aria-pressed={isSaved}
+        className={
+          isSaved
+            ? "rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-950 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-70"
+            : "rounded-md border border-zinc-300 px-3 py-2 text-sm font-medium text-zinc-950 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-70"
+        }
+      >
+        {isSaved ? "Saved" : "Save"}
+      </button>
+      {error ? <FormFeedback tone="error">{error}</FormFeedback> : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/saved-listings/mutations.test.ts
+++ b/apps/web/src/features/saved-listings/mutations.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  saveListing,
+  unsaveListing,
+} from "@/features/saved-listings/mutations";
+import { prisma } from "@/server/db/prisma";
+
+vi.mock("@/server/db/prisma", () => ({
+  prisma: {
+    savedListing: {
+      deleteMany: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+const userId = "507f1f77bcf86cd799439099";
+const listingId = "507f1f77bcf86cd799439011";
+
+describe("saved listing mutations", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.savedListing.deleteMany).mockReset();
+    vi.mocked(prisma.savedListing.upsert).mockReset();
+    process.env.DATABASE_URL = "mongodb://example.test/allapartments";
+  });
+
+  it("saves a listing idempotently for a user", async () => {
+    vi.mocked(prisma.savedListing.upsert).mockResolvedValue({
+      id: "507f1f77bcf86cd799439222",
+      userId,
+      listingId,
+      createdAt: new Date("2026-05-20T12:00:00.000Z"),
+    });
+
+    await saveListing(userId, listingId);
+
+    expect(prisma.savedListing.upsert).toHaveBeenCalledWith({
+      where: {
+        userId_listingId: {
+          userId,
+          listingId,
+        },
+      },
+      create: {
+        user: {
+          connect: {
+            id: userId,
+          },
+        },
+        listing: {
+          connect: {
+            id: listingId,
+          },
+        },
+      },
+      update: {},
+    });
+  });
+
+  it("removes a saved listing without requiring an existing row", async () => {
+    vi.mocked(prisma.savedListing.deleteMany).mockResolvedValue({ count: 0 });
+
+    await expect(unsaveListing(userId, listingId)).resolves.toEqual({
+      saved: false,
+    });
+
+    expect(prisma.savedListing.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId,
+        listingId,
+      },
+    });
+  });
+});

--- a/apps/web/src/features/saved-listings/mutations.ts
+++ b/apps/web/src/features/saved-listings/mutations.ts
@@ -1,0 +1,48 @@
+import { prisma } from "@/server/db/prisma";
+
+function hasDatabaseUrl() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+export async function saveListing(userId: string, listingId: string) {
+  if (!hasDatabaseUrl()) {
+    return null;
+  }
+
+  return prisma.savedListing.upsert({
+    where: {
+      userId_listingId: {
+        userId,
+        listingId,
+      },
+    },
+    create: {
+      user: {
+        connect: {
+          id: userId,
+        },
+      },
+      listing: {
+        connect: {
+          id: listingId,
+        },
+      },
+    },
+    update: {},
+  });
+}
+
+export async function unsaveListing(userId: string, listingId: string) {
+  if (!hasDatabaseUrl()) {
+    return null;
+  }
+
+  await prisma.savedListing.deleteMany({
+    where: {
+      userId,
+      listingId,
+    },
+  });
+
+  return { saved: false };
+}

--- a/apps/web/src/features/saved-listings/queries.test.ts
+++ b/apps/web/src/features/saved-listings/queries.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getSavedListingIdsByUser,
+  getSavedListingsByUser,
+} from "@/features/saved-listings/queries";
+import { prisma } from "@/server/db/prisma";
+
+vi.mock("@/server/db/prisma", () => ({
+  prisma: {
+    savedListing: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+describe("saved listing queries", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.savedListing.findMany).mockReset();
+    process.env.DATABASE_URL = "mongodb://example.test/allapartments";
+  });
+
+  it("returns saved listing ids for the signed-in user", async () => {
+    vi.mocked(prisma.savedListing.findMany).mockResolvedValue([
+      { listingId: "507f1f77bcf86cd799439011" },
+    ]);
+
+    await expect(
+      getSavedListingIdsByUser("507f1f77bcf86cd799439099"),
+    ).resolves.toEqual(["507f1f77bcf86cd799439011"]);
+
+    expect(prisma.savedListing.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: "507f1f77bcf86cd799439099",
+      },
+      select: {
+        listingId: true,
+      },
+    });
+  });
+
+  it("returns active saved listings newest-first for profile display", async () => {
+    const listing = {
+      id: "507f1f77bcf86cd799439011",
+      title: "Saved room",
+    };
+    vi.mocked(prisma.savedListing.findMany).mockResolvedValue([{ listing }]);
+
+    await expect(
+      getSavedListingsByUser("507f1f77bcf86cd799439099"),
+    ).resolves.toEqual([listing]);
+
+    expect(prisma.savedListing.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: "507f1f77bcf86cd799439099",
+        listing: {
+          status: "ACTIVE",
+        },
+      },
+      include: {
+        listing: true,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+  });
+});

--- a/apps/web/src/features/saved-listings/queries.ts
+++ b/apps/web/src/features/saved-listings/queries.ts
@@ -1,0 +1,47 @@
+import { ListingStatus } from "@prisma/client";
+
+import { prisma } from "@/server/db/prisma";
+
+function hasDatabaseUrl() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+export async function getSavedListingIdsByUser(userId: string) {
+  if (!hasDatabaseUrl()) {
+    return [];
+  }
+
+  const savedListings = await prisma.savedListing.findMany({
+    where: {
+      userId,
+    },
+    select: {
+      listingId: true,
+    },
+  });
+
+  return savedListings.map((savedListing) => savedListing.listingId);
+}
+
+export async function getSavedListingsByUser(userId: string) {
+  if (!hasDatabaseUrl()) {
+    return [];
+  }
+
+  const savedListings = await prisma.savedListing.findMany({
+    where: {
+      userId,
+      listing: {
+        status: ListingStatus.ACTIVE,
+      },
+    },
+    include: {
+      listing: true,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+  return savedListings.map((savedListing) => savedListing.listing);
+}

--- a/apps/web/src/features/saved-listings/schemas.ts
+++ b/apps/web/src/features/saved-listings/schemas.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const savedListingResponseSchema = z.object({
+  saved: z.boolean(),
+});

--- a/apps/web/src/server/api/openapi.test.ts
+++ b/apps/web/src/server/api/openapi.test.ts
@@ -15,6 +15,8 @@ describe("OpenAPI document", () => {
     expect(document.paths["/api/listings/{id}"]?.delete).toBeDefined();
     expect(document.paths["/api/listings/{id}/reviews"]?.get).toBeDefined();
     expect(document.paths["/api/listings/{id}/reviews"]?.post).toBeDefined();
+    expect(document.paths["/api/listings/{id}/save"]?.post).toBeDefined();
+    expect(document.paths["/api/listings/{id}/save"]?.delete).toBeDefined();
     expect(document.paths["/api/reviews/{reviewId}"]?.patch).toBeDefined();
     expect(document.paths["/api/reviews/{reviewId}"]?.delete).toBeDefined();
     expect(document.components?.schemas?.ApiErrorResponse).toBeDefined();
@@ -22,6 +24,7 @@ describe("OpenAPI document", () => {
     expect(document.components?.schemas?.ReviewDetailResponse).toBeDefined();
     expect(document.paths["/api/listings"]?.post?.responses?.[401]).toBeDefined();
     expect(document.paths["/api/listings/{id}"]?.patch?.responses?.[403]).toBeDefined();
+    expect(document.paths["/api/listings/{id}/save"]?.post?.responses?.[401]).toBeDefined();
     expect(document.paths["/api/reviews/{reviewId}"]?.patch?.responses?.[403]).toBeDefined();
   });
 });

--- a/apps/web/src/server/api/openapi.ts
+++ b/apps/web/src/server/api/openapi.ts
@@ -25,6 +25,7 @@ import {
   reviewUpdateBodySchema,
   reviewsResponseSchema,
 } from "@/features/reviews/schemas";
+import { savedListingResponseSchema } from "@/features/saved-listings/schemas";
 
 extendZodWithOpenApi(z);
 
@@ -73,6 +74,7 @@ export function createOpenApiDocument() {
   registry.register("ReviewUpdateBody", reviewUpdateBodySchema);
   registry.register("ReviewsResponse", reviewsResponseSchema);
   registry.register("ReviewDetailResponse", reviewDetailResponseSchema);
+  registry.register("SavedListingResponse", savedListingResponseSchema);
 
   registry.registerPath({
     method: "post",
@@ -189,6 +191,40 @@ export function createOpenApiDocument() {
     responses: {
       200: jsonContent(reviewsResponseSchema, "Listing reviews response."),
       400: jsonContent(apiErrorResponseSchema, "Validation error response."),
+      500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/api/listings/{id}/save",
+    summary: "Save listing",
+    description:
+      "Saves a listing for the signed-in user. Repeated saves are idempotent.",
+    request: {
+      params: listingParamsSchema,
+    },
+    responses: {
+      200: jsonContent(savedListingResponseSchema, "Saved listing response."),
+      400: jsonContent(apiErrorResponseSchema, "Validation error response."),
+      401: jsonContent(apiErrorResponseSchema, "Authentication required response."),
+      500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
+    },
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/api/listings/{id}/save",
+    summary: "Unsave listing",
+    description:
+      "Removes a saved listing for the signed-in user. Missing saved rows are treated as already removed.",
+    request: {
+      params: listingParamsSchema,
+    },
+    responses: {
+      200: jsonContent(savedListingResponseSchema, "Unsaved listing response."),
+      400: jsonContent(apiErrorResponseSchema, "Validation error response."),
+      401: jsonContent(apiErrorResponseSchema, "Authentication required response."),
       500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
     },
   });


### PR DESCRIPTION
## Summary
- Add saved-listing persistence with a Prisma join model and unique user/listing constraint.
- Add authenticated save/unsave API routes for listings.
- Show saved state on listing cards/detail pages and add a Saved listings section to profile.
- Extend dev seed data and OpenAPI coverage for saved listings.

## Validation
- `npm test`
- `npm run lint`
- `npm run build`

## Notes
- `npx prisma db push` was already run locally for the new `SavedListing` collection and indexes.
- `npm run db:seed` was already run locally and now reports 2 saved listing fixtures.