### PR TITLE
Add structured contact requests

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -28,30 +28,38 @@ enum PetPolicy {
   PETS_ALLOWED
 }
 
+enum ContactMethod {
+  EMAIL
+  PHONE
+  ANY
+}
+
 model User {
-  id            String         @id @default(auto()) @map("_id") @db.ObjectId
-  email         String         @unique
-  name          String?
-  image         String?
-  contactEmail  String?
-  contactPhone  String?
-  passwordHash  String?
-  listings      Listing[]
-  reviews       Review[]
-  savedListings SavedListing[]
-  createdAt     DateTime       @default(now())
-  updatedAt     DateTime       @updatedAt
+  id                      String           @id @default(auto()) @map("_id") @db.ObjectId
+  email                   String           @unique
+  name                    String?
+  image                   String?
+  contactEmail            String?
+  contactPhone            String?
+  passwordHash            String?
+  listings                Listing[]
+  reviews                 Review[]
+  savedListings           SavedListing[]
+  contactRequestsSent     ContactRequest[] @relation("ContactRequestRequester")
+  contactRequestsReceived ContactRequest[] @relation("ContactRequestOwner")
+  createdAt               DateTime         @default(now())
+  updatedAt               DateTime         @updatedAt
 }
 
 model Listing {
-  id                  String         @id @default(auto()) @map("_id") @db.ObjectId
+  id                  String           @id @default(auto()) @map("_id") @db.ObjectId
   title               String
   type                ListingType
-  status              ListingStatus  @default(ACTIVE)
+  status              ListingStatus    @default(ACTIVE)
   description         String
   rent                Int
   deposit             Int?
-  utilitiesIncluded   Boolean        @default(false)
+  utilitiesIncluded   Boolean          @default(false)
   availableFrom       DateTime?
   leaseDuration       String?
   address             String?
@@ -60,7 +68,7 @@ model Listing {
   contactPhone        String?
   bedrooms            Int?
   bathrooms           Float?
-  petPolicy           PetPolicy      @default(UNKNOWN)
+  petPolicy           PetPolicy        @default(UNKNOWN)
   amenities           String[]
   imageUrls           String[]
   roommateCount       Int?
@@ -69,12 +77,13 @@ model Listing {
   cleanliness         String?
   smokingPolicy       String?
   roommatePreferences String?
-  ownerId             String?        @db.ObjectId
-  owner               User?          @relation(fields: [ownerId], references: [id])
+  ownerId             String?          @db.ObjectId
+  owner               User?            @relation(fields: [ownerId], references: [id])
   reviews             Review[]
   savedBy             SavedListing[]
-  createdAt           DateTime       @default(now())
-  updatedAt           DateTime       @updatedAt
+  contactRequests     ContactRequest[]
+  createdAt           DateTime         @default(now())
+  updatedAt           DateTime         @updatedAt
 
   @@index([status])
   @@index([type])
@@ -100,6 +109,26 @@ model SavedListing {
   @@unique([userId, listingId])
   @@index([userId, createdAt])
   @@index([listingId])
+}
+
+model ContactRequest {
+  id                     String        @id @default(auto()) @map("_id") @db.ObjectId
+  listingId              String        @db.ObjectId
+  listing                Listing       @relation(fields: [listingId], references: [id])
+  requesterId            String        @db.ObjectId
+  requester              User          @relation("ContactRequestRequester", fields: [requesterId], references: [id])
+  ownerId                String        @db.ObjectId
+  owner                  User          @relation("ContactRequestOwner", fields: [ownerId], references: [id])
+  message                String
+  preferredContactMethod ContactMethod @default(ANY)
+  contactEmail           String?
+  contactPhone           String?
+  createdAt              DateTime      @default(now())
+  updatedAt              DateTime      @updatedAt
+
+  @@index([listingId, createdAt])
+  @@index([requesterId, createdAt])
+  @@index([ownerId, createdAt])
 }
 
 model Review {

--- a/apps/web/prisma/seed-data.mjs
+++ b/apps/web/prisma/seed-data.mjs
@@ -170,6 +170,29 @@ export const DEV_SAVED_LISTINGS = [
   },
 ];
 
+export const DEV_CONTACT_REQUESTS = [
+  {
+    id: "66a000000000000000000501",
+    listingId: DEV_LISTINGS[0].id,
+    requesterId: DEV_USERS[2].id,
+    ownerId: DEV_USERS[0].id,
+    message: "I am interested in touring the studio this week.",
+    preferredContactMethod: "EMAIL",
+    contactEmail: DEV_USERS[2].contactEmail,
+    contactPhone: DEV_USERS[2].contactPhone,
+  },
+  {
+    id: "66a000000000000000000502",
+    listingId: DEV_LISTINGS[3].id,
+    requesterId: DEV_USERS[2].id,
+    ownerId: DEV_USERS[1].id,
+    message: "The roommate expectations look like a good fit for fall.",
+    preferredContactMethod: "ANY",
+    contactEmail: DEV_USERS[2].contactEmail,
+    contactPhone: DEV_USERS[2].contactPhone,
+  },
+];
+
 function userWriteData(user, passwordHash) {
   return {
     email: user.email,
@@ -246,6 +269,30 @@ function savedListingWriteData(savedListing) {
   };
 }
 
+function contactRequestWriteData(contactRequest) {
+  return {
+    message: contactRequest.message,
+    preferredContactMethod: contactRequest.preferredContactMethod,
+    contactEmail: contactRequest.contactEmail,
+    contactPhone: contactRequest.contactPhone,
+    listing: {
+      connect: {
+        id: contactRequest.listingId,
+      },
+    },
+    requester: {
+      connect: {
+        id: contactRequest.requesterId,
+      },
+    },
+    owner: {
+      connect: {
+        id: contactRequest.ownerId,
+      },
+    },
+  };
+}
+
 export async function seedDevData({ prisma, hashPassword }) {
   for (const user of DEV_USERS) {
     const passwordHash = await hashPassword(DEV_PASSWORD);
@@ -308,10 +355,26 @@ export async function seedDevData({ prisma, hashPassword }) {
     });
   }
 
+  for (const contactRequest of DEV_CONTACT_REQUESTS) {
+    const writeData = contactRequestWriteData(contactRequest);
+
+    await prisma.contactRequest.upsert({
+      where: {
+        id: contactRequest.id,
+      },
+      create: {
+        id: contactRequest.id,
+        ...writeData,
+      },
+      update: writeData,
+    });
+  }
+
   return {
     users: DEV_USERS.length,
     listings: DEV_LISTINGS.length,
     reviews: DEV_REVIEWS.length,
     savedListings: DEV_SAVED_LISTINGS.length,
+    contactRequests: DEV_CONTACT_REQUESTS.length,
   };
 }

--- a/apps/web/prisma/seed-data.test.mjs
+++ b/apps/web/prisma/seed-data.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   DEV_LISTINGS,
+  DEV_CONTACT_REQUESTS,
   DEV_REVIEWS,
   DEV_SAVED_LISTINGS,
   DEV_USERS,
@@ -22,6 +23,9 @@ function createPrismaMock() {
     savedListing: {
       upsert: vi.fn(),
     },
+    contactRequest: {
+      upsert: vi.fn(),
+    },
   };
 }
 
@@ -35,6 +39,7 @@ describe("dev seed data", () => {
     expect(DEV_LISTINGS.length).toBeGreaterThanOrEqual(4);
     expect(DEV_REVIEWS.length).toBeGreaterThanOrEqual(4);
     expect(DEV_SAVED_LISTINGS.length).toBeGreaterThanOrEqual(2);
+    expect(DEV_CONTACT_REQUESTS.length).toBeGreaterThanOrEqual(2);
     expect(roommateListing).toEqual(
       expect.objectContaining({
         roommateCount: 1,
@@ -60,6 +65,9 @@ describe("dev seed data", () => {
     expect(prisma.review.upsert).toHaveBeenCalledTimes(DEV_REVIEWS.length);
     expect(prisma.savedListing.upsert).toHaveBeenCalledTimes(
       DEV_SAVED_LISTINGS.length,
+    );
+    expect(prisma.contactRequest.upsert).toHaveBeenCalledTimes(
+      DEV_CONTACT_REQUESTS.length,
     );
     expect(hashPassword).toHaveBeenCalledTimes(DEV_USERS.length);
 
@@ -147,6 +155,31 @@ describe("dev seed data", () => {
           listing: {
             connect: {
               id: DEV_SAVED_LISTINGS[0].listingId,
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(prisma.contactRequest.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: DEV_CONTACT_REQUESTS[0].id },
+        create: expect.objectContaining({
+          id: DEV_CONTACT_REQUESTS[0].id,
+          message: DEV_CONTACT_REQUESTS[0].message,
+          listing: {
+            connect: {
+              id: DEV_CONTACT_REQUESTS[0].listingId,
+            },
+          },
+          requester: {
+            connect: {
+              id: DEV_CONTACT_REQUESTS[0].requesterId,
+            },
+          },
+          owner: {
+            connect: {
+              id: DEV_CONTACT_REQUESTS[0].ownerId,
             },
           },
         }),

--- a/apps/web/prisma/seed.mjs
+++ b/apps/web/prisma/seed.mjs
@@ -17,7 +17,7 @@ try {
   });
 
   console.log(
-    `Seeded dev data: ${result.users} users, ${result.listings} listings, ${result.reviews} reviews, ${result.savedListings} saved listings.`,
+    `Seeded dev data: ${result.users} users, ${result.listings} listings, ${result.reviews} reviews, ${result.savedListings} saved listings, ${result.contactRequests} contact requests.`,
   );
 } finally {
   await prisma.$disconnect();

--- a/apps/web/src/app/api/listings/[id]/contact-requests/route.test.ts
+++ b/apps/web/src/app/api/listings/[id]/contact-requests/route.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "@/app/api/listings/[id]/contact-requests/route";
+import { createContactRequest } from "@/features/contact-requests/mutations";
+import { requireCurrentUser } from "@/server/auth/current-user";
+
+vi.mock("@/features/contact-requests/mutations", () => ({
+  createContactRequest: vi.fn(),
+}));
+
+vi.mock("@/server/auth/current-user", () => ({
+  requireCurrentUser: vi.fn(),
+}));
+
+const contactRequest = {
+  id: "request-1",
+  listingId: "listing-1",
+  requesterId: "renter-1",
+  ownerId: "owner-1",
+  message: "I would like to tour this week.",
+  preferredContactMethod: "EMAIL" as const,
+  contactEmail: "renter@example.com",
+  contactPhone: null,
+  listing: {
+    title: "Sunny room near SCSU",
+  },
+  requester: {
+    name: "Renter One",
+    email: "renter@example.com",
+  },
+  owner: {
+    name: "Owner One",
+    email: "owner@example.com",
+  },
+  createdAt: new Date("2026-05-28T12:00:00.000Z"),
+  updatedAt: new Date("2026-05-28T12:00:00.000Z"),
+};
+
+describe("POST /api/listings/{id}/contact-requests", () => {
+  beforeEach(() => {
+    vi.mocked(requireCurrentUser).mockReset();
+    vi.mocked(createContactRequest).mockReset();
+  });
+
+  it("creates a contact request in the success envelope", async () => {
+    vi.mocked(requireCurrentUser).mockResolvedValue({
+      id: "renter-1",
+      email: "renter@example.com",
+      name: "Renter One",
+    });
+    vi.mocked(createContactRequest).mockResolvedValue(contactRequest);
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/listings/listing-1/contact-requests", {
+        method: "POST",
+        body: JSON.stringify({
+          message: "I would like to tour this week.",
+          preferredContactMethod: "EMAIL",
+          contactEmail: "renter@example.com",
+          contactPhone: "",
+        }),
+      }),
+      {
+        params: Promise.resolve({ id: "listing-1" }),
+      },
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        contactRequest: {
+          id: "request-1",
+          listingId: "listing-1",
+          listingTitle: "Sunny room near SCSU",
+          requesterId: "renter-1",
+          requesterName: "Renter One",
+          requesterEmail: "renter@example.com",
+          ownerId: "owner-1",
+          ownerName: "Owner One",
+          ownerEmail: "owner@example.com",
+          message: "I would like to tour this week.",
+          preferredContactMethod: "EMAIL",
+          contactEmail: "renter@example.com",
+          contactPhone: null,
+          createdAt: "2026-05-28T12:00:00.000Z",
+          updatedAt: "2026-05-28T12:00:00.000Z",
+        },
+      },
+    });
+    expect(createContactRequest).toHaveBeenCalledWith("listing-1", "renter-1", {
+      message: "I would like to tour this week.",
+      preferredContactMethod: "EMAIL",
+      contactEmail: "renter@example.com",
+      contactPhone: null,
+    });
+  });
+
+  it("returns validation errors for invalid payloads", async () => {
+    vi.mocked(requireCurrentUser).mockResolvedValue({
+      id: "renter-1",
+      email: "renter@example.com",
+      name: "Renter One",
+    });
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/listings/listing-1/contact-requests", {
+        method: "POST",
+        body: JSON.stringify({
+          message: "",
+        }),
+      }),
+      {
+        params: Promise.resolve({ id: "listing-1" }),
+      },
+    );
+
+    expect(response.status).toBe(400);
+    expect(createContactRequest).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/listings/[id]/contact-requests/route.ts
+++ b/apps/web/src/app/api/listings/[id]/contact-requests/route.ts
@@ -1,0 +1,45 @@
+import { createContactRequest } from "@/features/contact-requests/mutations";
+import {
+  contactRequestCreateBodySchema,
+  contactRequestDetailResponseSchema,
+  serializeContactRequest,
+} from "@/features/contact-requests/schemas";
+import { listingParamsSchema } from "@/features/listings/schemas";
+import { apiData, throwIfInvalid, withApiErrorHandling } from "@/server/api/responses";
+import { requireCurrentUser } from "@/server/auth/current-user";
+
+export const dynamic = "force-dynamic";
+
+type ListingContactRequestsRouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function POST(
+  request: Request,
+  context: ListingContactRequestsRouteContext,
+) {
+  return withApiErrorHandling(async () => {
+    const currentUser = await requireCurrentUser();
+    const params = throwIfInvalid(
+      listingParamsSchema.safeParse(await context.params),
+    );
+    const input = throwIfInvalid(
+      contactRequestCreateBodySchema.safeParse(await request.json()),
+    );
+
+    const contactRequest = await createContactRequest(
+      params.id,
+      currentUser.id,
+      input,
+    );
+
+    return apiData(
+      contactRequestDetailResponseSchema.parse({
+        contactRequest: contactRequest
+          ? serializeContactRequest(contactRequest)
+          : null,
+      }),
+      { status: 201 },
+    );
+  });
+}

--- a/apps/web/src/app/listings/[id]/page.test.tsx
+++ b/apps/web/src/app/listings/[id]/page.test.tsx
@@ -2,12 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ListingDetailPage from "@/app/listings/[id]/page";
 import { getListingById } from "@/features/listings/queries";
+import { getProfileUser } from "@/features/profile/queries";
 import { getReviewsForListing } from "@/features/reviews/mutations";
 import { getSavedListingIdsByUser } from "@/features/saved-listings/queries";
 import { auth } from "@/server/auth/auth";
 
 vi.mock("@/features/listings/queries", () => ({
   getListingById: vi.fn(),
+}));
+
+vi.mock("@/features/profile/queries", () => ({
+  getProfileUser: vi.fn(),
 }));
 
 vi.mock("@/features/reviews/mutations", () => ({
@@ -103,11 +108,50 @@ function includesText(
   return values.some((value) => includesText(value, text, seen));
 }
 
+function hasContactRequestForm(
+  node: unknown,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (Array.isArray(node)) {
+    return node.some((child) => hasContactRequestForm(child, seen));
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  if (seen.has(node)) {
+    return false;
+  }
+  seen.add(node);
+
+  const element = node as {
+    props?: {
+      listingId?: unknown;
+      defaultContactEmail?: unknown;
+      children?: unknown;
+    };
+  };
+
+  if (
+    element.props?.listingId === listing.id &&
+    element.props?.defaultContactEmail === "renter@example.com"
+  ) {
+    return true;
+  }
+
+  return Object.values(element.props ?? {}).some((value) =>
+    hasContactRequestForm(value, seen),
+  );
+}
+
 describe("ListingDetailPage", () => {
   beforeEach(() => {
     vi.mocked(getSavedListingIdsByUser).mockReset();
+    vi.mocked(getProfileUser).mockReset();
     vi.mocked(getReviewsForListing).mockResolvedValue([]);
     vi.mocked(getSavedListingIdsByUser).mockResolvedValue([]);
+    vi.mocked(getProfileUser).mockResolvedValue(null);
   });
 
   it("shows edit controls for the listing owner", async () => {
@@ -173,5 +217,30 @@ describe("ListingDetailPage", () => {
 
     expect(includesText(page, "Roommate fit")).toBe(true);
     expect(includesText(page, "Shared chores weekly")).toBe(true);
+  });
+
+  it("shows the contact request form for signed-in non-owners", async () => {
+    vi.mocked(getListingById).mockResolvedValue(listing);
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "507f1f77bcf86cd799439088",
+        email: "renter@example.com",
+      },
+      expires: "2026-06-01T00:00:00.000Z",
+    });
+    vi.mocked(getProfileUser).mockResolvedValue({
+      id: "507f1f77bcf86cd799439088",
+      email: "renter@example.com",
+      name: "Renter One",
+      contactEmail: "renter@example.com",
+      contactPhone: "320-555-0103",
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+    });
+
+    const page = await ListingDetailPage({
+      params: Promise.resolve({ id: listing.id }),
+    });
+
+    expect(hasContactRequestForm(page)).toBe(true);
   });
 });

--- a/apps/web/src/app/listings/[id]/page.tsx
+++ b/apps/web/src/app/listings/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { getListingById } from "@/features/listings/queries";
 import { ListingArchiveButton } from "@/features/listings/components/listing-archive-button";
 import { ListingImageGallery } from "@/features/listings/components/listing-image-gallery";
+import { ContactRequestForm } from "@/features/contact-requests/components/contact-request-form";
+import { getProfileUser } from "@/features/profile/queries";
 import { ReviewSection } from "@/features/reviews/components/review-section";
 import { getReviewsForListing } from "@/features/reviews/mutations";
 import { serializeReview } from "@/features/reviews/schemas";
@@ -34,6 +36,9 @@ export default async function ListingDetailPage({
   const savedListingIds = session?.user?.id
     ? await getSavedListingIdsByUser(session.user.id)
     : [];
+  const profileUser = session?.user?.id && !isOwner
+    ? await getProfileUser(session.user.id)
+    : null;
   const isSaved = savedListingIds.includes(listing.id);
   const hasContactInfo = Boolean(listing.contactEmail || listing.contactPhone);
   const roommateDetails =
@@ -162,6 +167,16 @@ export default async function ListingDetailPage({
             ) : null}
           </div>
         </section>
+      ) : null}
+
+      {!isOwner && session?.user?.id ? (
+        <ContactRequestForm
+          listingId={listing.id}
+          defaultContactEmail={
+            profileUser?.contactEmail ?? session.user.email ?? null
+          }
+          defaultContactPhone={profileUser?.contactPhone ?? null}
+        />
       ) : null}
 
       {listing.amenities.length > 0 ? (

--- a/apps/web/src/app/profile/page.test.tsx
+++ b/apps/web/src/app/profile/page.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
 import ProfilePage from "@/app/profile/page";
+import {
+  getReceivedContactRequestsByOwner,
+  getSentContactRequestsByRequester,
+} from "@/features/contact-requests/queries";
 import { getListingsByOwner } from "@/features/listings/queries";
 import { getProfileUser } from "@/features/profile/queries";
 import { getSavedListingsByUser } from "@/features/saved-listings/queries";
@@ -8,6 +12,11 @@ import { auth } from "@/server/auth/auth";
 
 vi.mock("@/features/listings/queries", () => ({
   getListingsByOwner: vi.fn(),
+}));
+
+vi.mock("@/features/contact-requests/queries", () => ({
+  getReceivedContactRequestsByOwner: vi.fn(),
+  getSentContactRequestsByRequester: vi.fn(),
 }));
 
 vi.mock("@/features/profile/queries", () => ({
@@ -194,6 +203,36 @@ function hasListingPropTitle(
   );
 }
 
+function hasContactRequestsProp(
+  node: unknown,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (Array.isArray(node)) {
+    return node.some((child) => hasContactRequestsProp(child, seen));
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  if (seen.has(node)) {
+    return false;
+  }
+  seen.add(node);
+
+  const element = node as {
+    props?: { contactRequests?: unknown[]; children?: unknown };
+  };
+
+  if (Array.isArray(element.props?.contactRequests)) {
+    return true;
+  }
+
+  return Object.values(element.props ?? {}).some((value) =>
+    hasContactRequestsProp(value, seen),
+  );
+}
+
 describe("ProfilePage", () => {
   it("redirects signed-out users to login with a callback", async () => {
     vi.mocked(auth).mockResolvedValue(null);
@@ -205,6 +244,8 @@ describe("ProfilePage", () => {
     expect(getProfileUser).not.toHaveBeenCalled();
     expect(getListingsByOwner).not.toHaveBeenCalled();
     expect(getSavedListingsByUser).not.toHaveBeenCalled();
+    expect(getReceivedContactRequestsByOwner).not.toHaveBeenCalled();
+    expect(getSentContactRequestsByRequester).not.toHaveBeenCalled();
   });
 
   it("renders the signed-in user's profile and all owned listing statuses", async () => {
@@ -226,12 +267,16 @@ describe("ProfilePage", () => {
     });
     vi.mocked(getListingsByOwner).mockResolvedValue(ownedListings);
     vi.mocked(getSavedListingsByUser).mockResolvedValue(savedListings);
+    vi.mocked(getReceivedContactRequestsByOwner).mockResolvedValue([]);
+    vi.mocked(getSentContactRequestsByRequester).mockResolvedValue([]);
 
     const page = await ProfilePage();
 
     expect(getProfileUser).toHaveBeenCalledWith(ownerId);
     expect(getListingsByOwner).toHaveBeenCalledWith(ownerId);
     expect(getSavedListingsByUser).toHaveBeenCalledWith(ownerId);
+    expect(getReceivedContactRequestsByOwner).toHaveBeenCalledWith(ownerId);
+    expect(getSentContactRequestsByRequester).toHaveBeenCalledWith(ownerId);
     expect(includesText(page, "Owner Name")).toBe(true);
     expect(includesText(page, "owner@example.com")).toBe(true);
     expect(includesText(page, "Account basics")).toBe(true);
@@ -240,6 +285,7 @@ describe("ProfilePage", () => {
     expect(includesText(page, "Archived studio")).toBe(true);
     expect(includesText(page, "ARCHIVED")).toBe(true);
     expect(includesText(page, "Saved listings")).toBe(true);
+    expect(hasContactRequestsProp(page)).toBe(true);
     expect(hasListingPropTitle(page, "Saved studio near campus")).toBe(true);
     expect(hasHref(page, "/listings/507f1f77bcf86cd799439011/edit")).toBe(true);
   });

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -2,6 +2,15 @@ import type { Listing } from "@prisma/client";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import {
+  ContactRequestsReceivedList,
+  ContactRequestsSentList,
+} from "@/features/contact-requests/components/contact-request-lists";
+import {
+  getReceivedContactRequestsByOwner,
+  getSentContactRequestsByRequester,
+} from "@/features/contact-requests/queries";
+import { serializeContactRequest } from "@/features/contact-requests/schemas";
 import { ListingArchiveButton } from "@/features/listings/components/listing-archive-button";
 import { ListingCard } from "@/features/listings/components/listing-card";
 import { getListingsByOwner } from "@/features/listings/queries";
@@ -70,10 +79,18 @@ export default async function ProfilePage() {
     redirect("/login?callbackUrl=%2Fprofile");
   }
 
-  const [profileUser, listings, savedListings] = await Promise.all([
+  const [
+    profileUser,
+    listings,
+    savedListings,
+    receivedContactRequests,
+    sentContactRequests,
+  ] = await Promise.all([
     getProfileUser(session.user.id),
     getListingsByOwner(session.user.id),
     getSavedListingsByUser(session.user.id),
+    getReceivedContactRequestsByOwner(session.user.id),
+    getSentContactRequestsByRequester(session.user.id),
   ]);
   const displayName = profileUser?.name ?? session.user.name ?? "Renter";
   const email = profileUser?.email ?? session.user.email;
@@ -155,6 +172,14 @@ export default async function ProfilePage() {
           </div>
         )}
       </section>
+
+      <ContactRequestsReceivedList
+        contactRequests={receivedContactRequests.map(serializeContactRequest)}
+      />
+
+      <ContactRequestsSentList
+        contactRequests={sentContactRequests.map(serializeContactRequest)}
+      />
 
       <section className="mt-8">
         <div className="flex flex-wrap items-end justify-between gap-3">

--- a/apps/web/src/features/contact-requests/components/contact-request-form.test.tsx
+++ b/apps/web/src/features/contact-requests/components/contact-request-form.test.tsx
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { contactRequestPayloadFromFormData } from "@/features/contact-requests/components/contact-request-form";
+import {
+  contactRequestPayloadFromFormData,
+  submitContactRequest,
+} from "@/features/contact-requests/components/contact-request-form";
 
 describe("contactRequestPayloadFromFormData", () => {
   it("normalizes contact request form data", () => {
@@ -16,5 +19,51 @@ describe("contactRequestPayloadFromFormData", () => {
       contactEmail: "renter@example.com",
       contactPhone: null,
     });
+  });
+});
+
+describe("submitContactRequest", () => {
+  it("treats a created contact request response as success", async () => {
+    const formData = new FormData();
+    formData.set("message", "I would like to tour this week.");
+    formData.set("preferredContactMethod", "EMAIL");
+    formData.set("contactEmail", "renter@example.com");
+    formData.set("contactPhone", "");
+    const fetcher = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));
+
+    await expect(
+      submitContactRequest({
+        fetcher,
+        formData,
+        listingId: "listing-1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "/api/listings/listing-1/contact-requests",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
+
+  it("uses the API error message when contact request creation fails", async () => {
+    const formData = new FormData();
+    formData.set("message", "I would like to tour this week.");
+    formData.set("preferredContactMethod", "EMAIL");
+    const fetcher = vi.fn().mockResolvedValue(
+      Response.json(
+        { error: { message: "Contact email or phone is required." } },
+        { status: 400 },
+      ),
+    );
+
+    await expect(
+      submitContactRequest({
+        fetcher,
+        formData,
+        listingId: "listing-1",
+      }),
+    ).rejects.toThrow("Contact email or phone is required.");
   });
 });

--- a/apps/web/src/features/contact-requests/components/contact-request-form.test.tsx
+++ b/apps/web/src/features/contact-requests/components/contact-request-form.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { contactRequestPayloadFromFormData } from "@/features/contact-requests/components/contact-request-form";
+
+describe("contactRequestPayloadFromFormData", () => {
+  it("normalizes contact request form data", () => {
+    const formData = new FormData();
+    formData.set("message", "  I would like to tour this week.  ");
+    formData.set("preferredContactMethod", "PHONE");
+    formData.set("contactEmail", " renter@example.com ");
+    formData.set("contactPhone", "");
+
+    expect(contactRequestPayloadFromFormData(formData)).toEqual({
+      message: "I would like to tour this week.",
+      preferredContactMethod: "PHONE",
+      contactEmail: "renter@example.com",
+      contactPhone: null,
+    });
+  });
+});

--- a/apps/web/src/features/contact-requests/components/contact-request-form.tsx
+++ b/apps/web/src/features/contact-requests/components/contact-request-form.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+
+import { type ContactRequestCreateInput } from "@/features/contact-requests/schemas";
+import { FormFeedback } from "@/features/ui/form-feedback";
+
+type ApiErrorBody = {
+  error?: {
+    message?: string;
+  };
+};
+
+type ContactRequestFormProps = {
+  listingId: string;
+  defaultContactEmail?: string | null;
+  defaultContactPhone?: string | null;
+};
+
+function stringValue(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function nullableStringValue(formData: FormData, key: string) {
+  const value = stringValue(formData, key);
+  return value.length > 0 ? value : null;
+}
+
+async function readErrorMessage(response: Response, fallback: string) {
+  const body = (await response.json().catch(() => null)) as ApiErrorBody | null;
+  return body?.error?.message ?? fallback;
+}
+
+export function contactRequestPayloadFromFormData(
+  formData: FormData,
+): ContactRequestCreateInput {
+  return {
+    message: stringValue(formData, "message"),
+    preferredContactMethod: stringValue(
+      formData,
+      "preferredContactMethod",
+    ) as ContactRequestCreateInput["preferredContactMethod"],
+    contactEmail: nullableStringValue(formData, "contactEmail"),
+    contactPhone: nullableStringValue(formData, "contactPhone"),
+  };
+}
+
+export function ContactRequestForm({
+  listingId,
+  defaultContactEmail,
+  defaultContactPhone,
+}: ContactRequestFormProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setNotice("Sending request...");
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch(`/api/listings/${listingId}/contact-requests`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(
+          contactRequestPayloadFromFormData(new FormData(event.currentTarget)),
+        ),
+      });
+
+      if (!response.ok) {
+        setNotice(null);
+        setError(
+          await readErrorMessage(
+            response,
+            "Could not send request. Please try again.",
+          ),
+        );
+        return;
+      }
+
+      event.currentTarget.reset();
+      setNotice("Request sent.");
+      router.refresh();
+    } catch {
+      setNotice(null);
+      setError("Could not send request. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="mt-8 rounded-md border border-emerald-200 bg-emerald-50 px-5 py-4">
+      <h2 className="text-lg font-semibold text-emerald-950">
+        Contact poster
+      </h2>
+      <p className="mt-1 text-sm text-emerald-900">
+        Send a structured request so the poster can review it from their
+        profile.
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-4 grid gap-4">
+        {error ? <FormFeedback tone="error">{error}</FormFeedback> : null}
+        {notice ? (
+          <FormFeedback tone={isSubmitting ? "info" : "success"}>
+            {notice}
+          </FormFeedback>
+        ) : null}
+
+        <div className="grid gap-2">
+          <label htmlFor="message" className="text-sm font-medium text-emerald-950">
+            Message
+          </label>
+          <textarea
+            id="message"
+            name="message"
+            required
+            rows={4}
+            className="rounded-md border border-emerald-300 px-3 py-2 text-sm outline-none focus:border-emerald-900"
+            placeholder="Share your timing, questions, or tour availability."
+          />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <div className="grid gap-2">
+            <label
+              htmlFor="preferredContactMethod"
+              className="text-sm font-medium text-emerald-950"
+            >
+              Preferred contact
+            </label>
+            <select
+              id="preferredContactMethod"
+              name="preferredContactMethod"
+              defaultValue="ANY"
+              className="rounded-md border border-emerald-300 px-3 py-2 text-sm outline-none focus:border-emerald-900"
+            >
+              <option value="ANY">Any</option>
+              <option value="EMAIL">Email</option>
+              <option value="PHONE">Phone</option>
+            </select>
+          </div>
+
+          <div className="grid gap-2">
+            <label
+              htmlFor="contactEmail"
+              className="text-sm font-medium text-emerald-950"
+            >
+              Contact email
+            </label>
+            <input
+              id="contactEmail"
+              name="contactEmail"
+              type="email"
+              defaultValue={defaultContactEmail ?? ""}
+              className="rounded-md border border-emerald-300 px-3 py-2 text-sm outline-none focus:border-emerald-900"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <label
+              htmlFor="contactPhone"
+              className="text-sm font-medium text-emerald-950"
+            >
+              Contact phone
+            </label>
+            <input
+              id="contactPhone"
+              name="contactPhone"
+              type="tel"
+              defaultValue={defaultContactPhone ?? ""}
+              className="rounded-md border border-emerald-300 px-3 py-2 text-sm outline-none focus:border-emerald-900"
+            />
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-fit rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+        >
+          {isSubmitting ? "Sending..." : "Send request"}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/features/contact-requests/components/contact-request-form.tsx
+++ b/apps/web/src/features/contact-requests/components/contact-request-form.tsx
@@ -18,6 +18,12 @@ type ContactRequestFormProps = {
   defaultContactPhone?: string | null;
 };
 
+type SubmitContactRequestOptions = {
+  fetcher?: typeof fetch;
+  formData: FormData;
+  listingId: string;
+};
+
 function stringValue(formData: FormData, key: string) {
   const value = formData.get(key);
   return typeof value === "string" ? value.trim() : "";
@@ -47,6 +53,29 @@ export function contactRequestPayloadFromFormData(
   };
 }
 
+export async function submitContactRequest({
+  fetcher = fetch,
+  formData,
+  listingId,
+}: SubmitContactRequestOptions) {
+  const response = await fetcher(`/api/listings/${listingId}/contact-requests`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(contactRequestPayloadFromFormData(formData)),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      await readErrorMessage(
+        response,
+        "Could not send request. Please try again.",
+      ),
+    );
+  }
+}
+
 export function ContactRequestForm({
   listingId,
   defaultContactEmail,
@@ -59,41 +88,29 @@ export function ContactRequestForm({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
     setError(null);
     setNotice("Sending request...");
     setIsSubmitting(true);
 
     try {
-      const response = await fetch(`/api/listings/${listingId}/contact-requests`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(
-          contactRequestPayloadFromFormData(new FormData(event.currentTarget)),
-        ),
-      });
-
-      if (!response.ok) {
-        setNotice(null);
-        setError(
-          await readErrorMessage(
-            response,
-            "Could not send request. Please try again.",
-          ),
-        );
-        return;
-      }
-
-      event.currentTarget.reset();
-      setNotice("Request sent.");
-      router.refresh();
-    } catch {
+      await submitContactRequest({ formData, listingId });
+    } catch (submitError) {
       setNotice(null);
-      setError("Could not send request. Please try again.");
-    } finally {
+      setError(
+        submitError instanceof Error
+          ? submitError.message
+          : "Could not send request. Please try again.",
+      );
       setIsSubmitting(false);
+      return;
     }
+
+    form.reset();
+    setNotice("Request sent.");
+    router.refresh();
+    setIsSubmitting(false);
   }
 
   return (

--- a/apps/web/src/features/contact-requests/components/contact-request-lists.test.tsx
+++ b/apps/web/src/features/contact-requests/components/contact-request-lists.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ContactRequestsReceivedList,
+  ContactRequestsSentList,
+} from "@/features/contact-requests/components/contact-request-lists";
+import { serializeContactRequest } from "@/features/contact-requests/schemas";
+
+function includesText(
+  node: unknown,
+  text: string,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node).includes(text);
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  if (seen.has(node)) {
+    return false;
+  }
+  seen.add(node);
+
+  return Object.values(node).some((value) => includesText(value, text, seen));
+}
+
+const request = serializeContactRequest({
+  id: "request-1",
+  listingId: "listing-1",
+  requesterId: "renter-1",
+  ownerId: "owner-1",
+  message: "I would like to tour this week.",
+  preferredContactMethod: "EMAIL",
+  contactEmail: "renter@example.com",
+  contactPhone: null,
+  listing: {
+    title: "Sunny room near SCSU",
+  },
+  requester: {
+    name: "Renter One",
+    email: "renter@example.com",
+  },
+  owner: {
+    name: "Owner One",
+    email: "owner@example.com",
+  },
+  createdAt: new Date("2026-05-28T12:00:00.000Z"),
+  updatedAt: new Date("2026-05-28T12:00:00.000Z"),
+});
+
+describe("contact request profile lists", () => {
+  it("renders received request summaries", () => {
+    const list = ContactRequestsReceivedList({ contactRequests: [request] });
+
+    expect(includesText(list, "Requests received")).toBe(true);
+    expect(includesText(list, "Renter One")).toBe(true);
+    expect(includesText(list, "I would like to tour this week.")).toBe(true);
+  });
+
+  it("renders sent request summaries", () => {
+    const list = ContactRequestsSentList({ contactRequests: [request] });
+
+    expect(includesText(list, "Requests sent")).toBe(true);
+    expect(includesText(list, "Owner One")).toBe(true);
+    expect(includesText(list, "Sunny room near SCSU")).toBe(true);
+  });
+});

--- a/apps/web/src/features/contact-requests/components/contact-request-lists.test.tsx
+++ b/apps/web/src/features/contact-requests/components/contact-request-lists.test.tsx
@@ -27,6 +27,33 @@ function includesText(
   return Object.values(node).some((value) => includesText(value, text, seen));
 }
 
+function includesHref(
+  node: unknown,
+  href: string,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  if (seen.has(node)) {
+    return false;
+  }
+  seen.add(node);
+
+  if (
+    "props" in node &&
+    node.props &&
+    typeof node.props === "object" &&
+    "href" in node.props &&
+    node.props.href === href
+  ) {
+    return true;
+  }
+
+  return Object.values(node).some((value) => includesHref(value, href, seen));
+}
+
 const request = serializeContactRequest({
   id: "request-1",
   listingId: "listing-1",
@@ -58,6 +85,7 @@ describe("contact request profile lists", () => {
     expect(includesText(list, "Requests received")).toBe(true);
     expect(includesText(list, "Renter One")).toBe(true);
     expect(includesText(list, "I would like to tour this week.")).toBe(true);
+    expect(includesHref(list, "/listings/listing-1")).toBe(true);
   });
 
   it("renders sent request summaries", () => {
@@ -66,5 +94,6 @@ describe("contact request profile lists", () => {
     expect(includesText(list, "Requests sent")).toBe(true);
     expect(includesText(list, "Owner One")).toBe(true);
     expect(includesText(list, "Sunny room near SCSU")).toBe(true);
+    expect(includesHref(list, "/listings/listing-1")).toBe(true);
   });
 });

--- a/apps/web/src/features/contact-requests/components/contact-request-lists.tsx
+++ b/apps/web/src/features/contact-requests/components/contact-request-lists.tsx
@@ -1,0 +1,154 @@
+import { type ContactRequestApiResponse } from "@/features/contact-requests/schemas";
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function methodLabel(value: ContactRequestApiResponse["preferredContactMethod"]) {
+  if (value === "EMAIL") {
+    return "Email";
+  }
+
+  if (value === "PHONE") {
+    return "Phone";
+  }
+
+  return "Any";
+}
+
+type ContactRequestListProps = {
+  contactRequests: ContactRequestApiResponse[];
+};
+
+export function ContactRequestsReceivedList({
+  contactRequests,
+}: ContactRequestListProps) {
+  return (
+    <section className="mt-8">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold text-zinc-950">
+            Requests received
+          </h2>
+          <p className="mt-1 text-sm text-zinc-600">
+            Review renter interest across your listings.
+          </p>
+        </div>
+        <p className="text-sm font-medium text-zinc-500">
+          {contactRequests.length} total
+        </p>
+      </div>
+
+      {contactRequests.length === 0 ? (
+        <div className="mt-6 rounded-md border border-dashed border-zinc-300 px-6 py-8 text-center">
+          <h3 className="text-lg font-semibold text-zinc-950">
+            No requests received yet
+          </h3>
+          <p className="mx-auto mt-2 max-w-md text-sm text-zinc-600">
+            Requests from renters will show up here after they contact you from
+            a listing.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-6 grid gap-3">
+          {contactRequests.map((request) => (
+            <article
+              key={request.id}
+              className="rounded-md border border-zinc-200 p-4"
+            >
+              <div className="flex flex-wrap justify-between gap-3">
+                <div>
+                  <h3 className="font-semibold text-zinc-950">
+                    {request.listingTitle}
+                  </h3>
+                  <p className="mt-1 text-sm text-zinc-600">
+                    From {request.requesterName ?? request.requesterEmail ?? "Renter"}
+                  </p>
+                </div>
+                <p className="text-sm text-zinc-500">
+                  {formatDate(request.createdAt)}
+                </p>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-zinc-700">
+                {request.message}
+              </p>
+              <p className="mt-3 text-sm font-medium text-zinc-950">
+                Preferred contact: {methodLabel(request.preferredContactMethod)}
+              </p>
+              <p className="mt-1 text-sm text-zinc-600">
+                {[request.contactEmail, request.contactPhone].filter(Boolean).join(" · ")}
+              </p>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function ContactRequestsSentList({
+  contactRequests,
+}: ContactRequestListProps) {
+  return (
+    <section className="mt-8">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold text-zinc-950">
+            Requests sent
+          </h2>
+          <p className="mt-1 text-sm text-zinc-600">
+            Track the listings you contacted from the app.
+          </p>
+        </div>
+        <p className="text-sm font-medium text-zinc-500">
+          {contactRequests.length} total
+        </p>
+      </div>
+
+      {contactRequests.length === 0 ? (
+        <div className="mt-6 rounded-md border border-dashed border-zinc-300 px-6 py-8 text-center">
+          <h3 className="text-lg font-semibold text-zinc-950">
+            No requests sent yet
+          </h3>
+          <p className="mx-auto mt-2 max-w-md text-sm text-zinc-600">
+            Contact a poster from a listing detail page and your request will
+            appear here.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-6 grid gap-3">
+          {contactRequests.map((request) => (
+            <article
+              key={request.id}
+              className="rounded-md border border-zinc-200 p-4"
+            >
+              <div className="flex flex-wrap justify-between gap-3">
+                <div>
+                  <h3 className="font-semibold text-zinc-950">
+                    {request.listingTitle}
+                  </h3>
+                  <p className="mt-1 text-sm text-zinc-600">
+                    To {request.ownerName ?? request.ownerEmail ?? "Owner"}
+                  </p>
+                </div>
+                <p className="text-sm text-zinc-500">
+                  {formatDate(request.createdAt)}
+                </p>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-zinc-700">
+                {request.message}
+              </p>
+              <p className="mt-3 text-sm font-medium text-zinc-950">
+                Preferred contact: {methodLabel(request.preferredContactMethod)}
+              </p>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/contact-requests/components/contact-request-lists.tsx
+++ b/apps/web/src/features/contact-requests/components/contact-request-lists.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { type ContactRequestApiResponse } from "@/features/contact-requests/schemas";
 
 function formatDate(value: string) {
@@ -62,8 +64,13 @@ export function ContactRequestsReceivedList({
             >
               <div className="flex flex-wrap justify-between gap-3">
                 <div>
-                  <h3 className="font-semibold text-zinc-950">
-                    {request.listingTitle}
+                  <h3 className="font-semibold">
+                    <Link
+                      href={`/listings/${request.listingId}`}
+                      className="text-zinc-950 underline-offset-4 hover:underline"
+                    >
+                      {request.listingTitle}
+                    </Link>
                   </h3>
                   <p className="mt-1 text-sm text-zinc-600">
                     From {request.requesterName ?? request.requesterEmail ?? "Renter"}
@@ -128,8 +135,13 @@ export function ContactRequestsSentList({
             >
               <div className="flex flex-wrap justify-between gap-3">
                 <div>
-                  <h3 className="font-semibold text-zinc-950">
-                    {request.listingTitle}
+                  <h3 className="font-semibold">
+                    <Link
+                      href={`/listings/${request.listingId}`}
+                      className="text-zinc-950 underline-offset-4 hover:underline"
+                    >
+                      {request.listingTitle}
+                    </Link>
                   </h3>
                   <p className="mt-1 text-sm text-zinc-600">
                     To {request.ownerName ?? request.ownerEmail ?? "Owner"}

--- a/apps/web/src/features/contact-requests/mutations.test.ts
+++ b/apps/web/src/features/contact-requests/mutations.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createContactRequest } from "@/features/contact-requests/mutations";
+import { prisma } from "@/server/db/prisma";
+
+vi.mock("@/server/db/prisma", () => ({
+  prisma: {
+    listing: {
+      findUnique: vi.fn(),
+    },
+    contactRequest: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+const input = {
+  message: "I would like to tour this week.",
+  preferredContactMethod: "EMAIL" as const,
+  contactEmail: "renter@example.com",
+  contactPhone: null,
+};
+
+describe("contact request mutations", () => {
+  beforeEach(() => {
+    vi.stubEnv("DATABASE_URL", "mongodb://example");
+    vi.mocked(prisma.listing.findUnique).mockReset();
+    vi.mocked(prisma.contactRequest.create).mockReset();
+  });
+
+  it("creates a contact request for the listing owner", async () => {
+    vi.mocked(prisma.listing.findUnique).mockResolvedValue({
+      id: "listing-1",
+      ownerId: "owner-1",
+    });
+    vi.mocked(prisma.contactRequest.create).mockResolvedValue({
+      id: "request-1",
+    });
+
+    await createContactRequest("listing-1", "renter-1", input);
+
+    expect(prisma.contactRequest.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          message: "I would like to tour this week.",
+          preferredContactMethod: "EMAIL",
+          contactEmail: "renter@example.com",
+          contactPhone: null,
+          listing: { connect: { id: "listing-1" } },
+          requester: { connect: { id: "renter-1" } },
+          owner: { connect: { id: "owner-1" } },
+        },
+      }),
+    );
+  });
+
+  it("throws listing not found when the listing does not exist", async () => {
+    vi.mocked(prisma.listing.findUnique).mockResolvedValue(null);
+
+    await expect(
+      createContactRequest("missing-listing", "renter-1", input),
+    ).rejects.toMatchObject({
+      code: "LISTING_NOT_FOUND",
+      status: 404,
+    });
+  });
+
+  it("rejects owners contacting their own listing", async () => {
+    vi.mocked(prisma.listing.findUnique).mockResolvedValue({
+      id: "listing-1",
+      ownerId: "owner-1",
+    });
+
+    await expect(
+      createContactRequest("listing-1", "owner-1", input),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      status: 403,
+    });
+  });
+});

--- a/apps/web/src/features/contact-requests/mutations.ts
+++ b/apps/web/src/features/contact-requests/mutations.ts
@@ -1,0 +1,81 @@
+import { forbidden, listingNotFound } from "@/server/api/errors";
+import { prisma } from "@/server/db/prisma";
+
+import { type ContactRequestCreateInput } from "./schemas";
+
+function hasDatabaseUrl() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+const contactRequestInclude = {
+  listing: {
+    select: {
+      title: true,
+    },
+  },
+  requester: {
+    select: {
+      name: true,
+      email: true,
+    },
+  },
+  owner: {
+    select: {
+      name: true,
+      email: true,
+    },
+  },
+};
+
+export async function createContactRequest(
+  listingId: string,
+  requesterId: string,
+  input: ContactRequestCreateInput,
+) {
+  if (!hasDatabaseUrl()) {
+    return null;
+  }
+
+  const listing = await prisma.listing.findUnique({
+    where: {
+      id: listingId,
+    },
+    select: {
+      id: true,
+      ownerId: true,
+    },
+  });
+
+  if (!listing?.ownerId) {
+    throw listingNotFound(listingId);
+  }
+
+  if (listing.ownerId === requesterId) {
+    throw forbidden("Owners cannot contact themselves about their own listing.");
+  }
+
+  return prisma.contactRequest.create({
+    data: {
+      message: input.message,
+      preferredContactMethod: input.preferredContactMethod,
+      contactEmail: input.contactEmail,
+      contactPhone: input.contactPhone,
+      listing: {
+        connect: {
+          id: listingId,
+        },
+      },
+      requester: {
+        connect: {
+          id: requesterId,
+        },
+      },
+      owner: {
+        connect: {
+          id: listing.ownerId,
+        },
+      },
+    },
+    include: contactRequestInclude,
+  });
+}

--- a/apps/web/src/features/contact-requests/queries.test.ts
+++ b/apps/web/src/features/contact-requests/queries.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getReceivedContactRequestsByOwner,
+  getSentContactRequestsByRequester,
+} from "@/features/contact-requests/queries";
+import { prisma } from "@/server/db/prisma";
+
+vi.mock("@/server/db/prisma", () => ({
+  prisma: {
+    contactRequest: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+describe("contact request queries", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.contactRequest.findMany).mockReset();
+  });
+
+  it("returns an empty list without a database URL", async () => {
+    vi.stubEnv("DATABASE_URL", "");
+
+    await expect(getReceivedContactRequestsByOwner("owner-1")).resolves.toEqual(
+      [],
+    );
+    await expect(
+      getSentContactRequestsByRequester("renter-1"),
+    ).resolves.toEqual([]);
+    expect(prisma.contactRequest.findMany).not.toHaveBeenCalled();
+  });
+
+  it("reads received contact requests for owners", async () => {
+    vi.stubEnv("DATABASE_URL", "mongodb://example");
+    vi.mocked(prisma.contactRequest.findMany).mockResolvedValue([]);
+
+    await getReceivedContactRequestsByOwner("owner-1");
+
+    expect(prisma.contactRequest.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { ownerId: "owner-1" },
+        orderBy: { createdAt: "desc" },
+      }),
+    );
+  });
+
+  it("reads sent contact requests for requesters", async () => {
+    vi.stubEnv("DATABASE_URL", "mongodb://example");
+    vi.mocked(prisma.contactRequest.findMany).mockResolvedValue([]);
+
+    await getSentContactRequestsByRequester("renter-1");
+
+    expect(prisma.contactRequest.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { requesterId: "renter-1" },
+        orderBy: { createdAt: "desc" },
+      }),
+    );
+  });
+});

--- a/apps/web/src/features/contact-requests/queries.ts
+++ b/apps/web/src/features/contact-requests/queries.ts
@@ -1,0 +1,57 @@
+import { prisma } from "@/server/db/prisma";
+
+function hasDatabaseUrl() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+const contactRequestInclude = {
+  listing: {
+    select: {
+      title: true,
+    },
+  },
+  requester: {
+    select: {
+      name: true,
+      email: true,
+    },
+  },
+  owner: {
+    select: {
+      name: true,
+      email: true,
+    },
+  },
+};
+
+export async function getReceivedContactRequestsByOwner(ownerId: string) {
+  if (!hasDatabaseUrl()) {
+    return [];
+  }
+
+  return prisma.contactRequest.findMany({
+    where: {
+      ownerId,
+    },
+    include: contactRequestInclude,
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+}
+
+export async function getSentContactRequestsByRequester(requesterId: string) {
+  if (!hasDatabaseUrl()) {
+    return [];
+  }
+
+  return prisma.contactRequest.findMany({
+    where: {
+      requesterId,
+    },
+    include: contactRequestInclude,
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+}

--- a/apps/web/src/features/contact-requests/schemas.test.ts
+++ b/apps/web/src/features/contact-requests/schemas.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  contactRequestCreateBodySchema,
+  contactRequestResponseSchema,
+  serializeContactRequest,
+} from "@/features/contact-requests/schemas";
+
+describe("contact request schemas", () => {
+  it("normalizes create payload contact fields", () => {
+    expect(
+      contactRequestCreateBodySchema.parse({
+        message: "  I would like to tour this week.  ",
+        preferredContactMethod: "EMAIL",
+        contactEmail: " renter@example.com ",
+        contactPhone: "",
+      }),
+    ).toEqual({
+      message: "I would like to tour this week.",
+      preferredContactMethod: "EMAIL",
+      contactEmail: "renter@example.com",
+      contactPhone: null,
+    });
+  });
+
+  it("accepts serialized contact request responses", () => {
+    const parsed = contactRequestResponseSchema.parse({
+      id: "507f1f77bcf86cd799439011",
+      listingId: "507f1f77bcf86cd799439012",
+      listingTitle: "Sunny room near SCSU",
+      requesterId: "507f1f77bcf86cd799439013",
+      requesterName: "Renter One",
+      requesterEmail: "renter@example.com",
+      ownerId: "507f1f77bcf86cd799439014",
+      ownerName: "Owner One",
+      ownerEmail: "owner@example.com",
+      message: "I would like to tour this week.",
+      preferredContactMethod: "ANY",
+      contactEmail: "renter@example.com",
+      contactPhone: null,
+      createdAt: "2026-05-28T12:00:00.000Z",
+      updatedAt: "2026-05-28T12:00:00.000Z",
+    });
+
+    expect(parsed.listingTitle).toBe("Sunny room near SCSU");
+  });
+
+  it("serializes included listing and user summaries", () => {
+    const serialized = serializeContactRequest({
+      id: "507f1f77bcf86cd799439011",
+      listingId: "507f1f77bcf86cd799439012",
+      requesterId: "507f1f77bcf86cd799439013",
+      ownerId: "507f1f77bcf86cd799439014",
+      message: "I would like to tour this week.",
+      preferredContactMethod: "PHONE",
+      contactEmail: null,
+      contactPhone: "320-555-0103",
+      listing: {
+        title: "Sunny room near SCSU",
+      },
+      requester: {
+        name: "Renter One",
+        email: "renter@example.com",
+      },
+      owner: {
+        name: "Owner One",
+        email: "owner@example.com",
+      },
+      createdAt: new Date("2026-05-28T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-28T12:00:00.000Z"),
+    });
+
+    expect(serialized).toEqual({
+      id: "507f1f77bcf86cd799439011",
+      listingId: "507f1f77bcf86cd799439012",
+      listingTitle: "Sunny room near SCSU",
+      requesterId: "507f1f77bcf86cd799439013",
+      requesterName: "Renter One",
+      requesterEmail: "renter@example.com",
+      ownerId: "507f1f77bcf86cd799439014",
+      ownerName: "Owner One",
+      ownerEmail: "owner@example.com",
+      message: "I would like to tour this week.",
+      preferredContactMethod: "PHONE",
+      contactEmail: null,
+      contactPhone: "320-555-0103",
+      createdAt: "2026-05-28T12:00:00.000Z",
+      updatedAt: "2026-05-28T12:00:00.000Z",
+    });
+  });
+});

--- a/apps/web/src/features/contact-requests/schemas.ts
+++ b/apps/web/src/features/contact-requests/schemas.ts
@@ -1,0 +1,102 @@
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+import { z } from "zod";
+
+extendZodWithOpenApi(z);
+
+export const contactMethodSchema = z.enum(["EMAIL", "PHONE", "ANY"]);
+
+const nullableEmailSchema = z.preprocess(
+  (value) => (value === "" || value === null ? null : value),
+  z.string().trim().email().nullable(),
+);
+
+const nullablePhoneSchema = z.preprocess(
+  (value) => (value === "" || value === null ? null : value),
+  z.string().trim().min(7).max(30).nullable(),
+);
+
+export const contactRequestCreateBodySchema = z.object({
+  message: z.string().trim().min(1, "Message is required.").max(2000),
+  preferredContactMethod: contactMethodSchema.default("ANY"),
+  contactEmail: nullableEmailSchema.default(null),
+  contactPhone: nullablePhoneSchema.default(null),
+});
+
+export const contactRequestResponseSchema = z.object({
+  id: z.string(),
+  listingId: z.string(),
+  listingTitle: z.string(),
+  requesterId: z.string(),
+  requesterName: z.string().nullable(),
+  requesterEmail: z.string().email().nullable(),
+  ownerId: z.string(),
+  ownerName: z.string().nullable(),
+  ownerEmail: z.string().email().nullable(),
+  message: z.string(),
+  preferredContactMethod: contactMethodSchema,
+  contactEmail: z.string().email().nullable(),
+  contactPhone: z.string().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const contactRequestDetailResponseSchema = z.object({
+  contactRequest: contactRequestResponseSchema,
+});
+
+export const contactRequestsResponseSchema = z.object({
+  contactRequests: z.array(contactRequestResponseSchema),
+});
+
+export type ContactRequestCreateInput = z.infer<
+  typeof contactRequestCreateBodySchema
+>;
+export type ContactRequestApiResponse = z.infer<
+  typeof contactRequestResponseSchema
+>;
+
+type ContactRequestForApi = {
+  id: string;
+  listingId: string;
+  requesterId: string;
+  ownerId: string;
+  message: string;
+  preferredContactMethod: "EMAIL" | "PHONE" | "ANY";
+  contactEmail: string | null;
+  contactPhone: string | null;
+  listing?: {
+    title?: string | null;
+  } | null;
+  requester?: {
+    name?: string | null;
+    email?: string | null;
+  } | null;
+  owner?: {
+    name?: string | null;
+    email?: string | null;
+  } | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export function serializeContactRequest(
+  contactRequest: ContactRequestForApi,
+): ContactRequestApiResponse {
+  return contactRequestResponseSchema.parse({
+    id: contactRequest.id,
+    listingId: contactRequest.listingId,
+    listingTitle: contactRequest.listing?.title ?? "Listing",
+    requesterId: contactRequest.requesterId,
+    requesterName: contactRequest.requester?.name ?? null,
+    requesterEmail: contactRequest.requester?.email ?? null,
+    ownerId: contactRequest.ownerId,
+    ownerName: contactRequest.owner?.name ?? null,
+    ownerEmail: contactRequest.owner?.email ?? null,
+    message: contactRequest.message,
+    preferredContactMethod: contactRequest.preferredContactMethod,
+    contactEmail: contactRequest.contactEmail,
+    contactPhone: contactRequest.contactPhone,
+    createdAt: contactRequest.createdAt.toISOString(),
+    updatedAt: contactRequest.updatedAt.toISOString(),
+  });
+}

--- a/apps/web/src/server/api/openapi.test.ts
+++ b/apps/web/src/server/api/openapi.test.ts
@@ -15,6 +15,7 @@ describe("OpenAPI document", () => {
     expect(document.paths["/api/listings/{id}"]?.delete).toBeDefined();
     expect(document.paths["/api/listings/{id}/reviews"]?.get).toBeDefined();
     expect(document.paths["/api/listings/{id}/reviews"]?.post).toBeDefined();
+    expect(document.paths["/api/listings/{id}/contact-requests"]?.post).toBeDefined();
     expect(document.paths["/api/listings/{id}/save"]?.post).toBeDefined();
     expect(document.paths["/api/listings/{id}/save"]?.delete).toBeDefined();
     expect(document.paths["/api/reviews/{reviewId}"]?.patch).toBeDefined();
@@ -22,6 +23,8 @@ describe("OpenAPI document", () => {
     expect(document.components?.schemas?.ApiErrorResponse).toBeDefined();
     expect(document.components?.schemas?.RegisterResponse).toBeDefined();
     expect(document.components?.schemas?.ReviewDetailResponse).toBeDefined();
+    expect(document.components?.schemas?.ContactRequestCreateBody).toBeDefined();
+    expect(document.components?.schemas?.ContactRequestDetailResponse).toBeDefined();
     expect(document.components?.schemas?.ListingCreateBody).toMatchObject({
       properties: expect.objectContaining({
         roommatePreferences: expect.any(Object),
@@ -43,6 +46,12 @@ describe("OpenAPI document", () => {
     });
     expect(document.paths["/api/listings"]?.post?.responses?.[401]).toBeDefined();
     expect(document.paths["/api/listings/{id}"]?.patch?.responses?.[403]).toBeDefined();
+    expect(
+      document.paths["/api/listings/{id}/contact-requests"]?.post?.responses?.[401],
+    ).toBeDefined();
+    expect(
+      document.paths["/api/listings/{id}/contact-requests"]?.post?.responses?.[403],
+    ).toBeDefined();
     expect(document.paths["/api/listings/{id}/save"]?.post?.responses?.[401]).toBeDefined();
     expect(document.paths["/api/reviews/{reviewId}"]?.patch?.responses?.[403]).toBeDefined();
   });

--- a/apps/web/src/server/api/openapi.ts
+++ b/apps/web/src/server/api/openapi.ts
@@ -10,6 +10,10 @@ import {
   registerResponseSchema,
 } from "@/features/auth/schemas";
 import {
+  contactRequestCreateBodySchema,
+  contactRequestDetailResponseSchema,
+} from "@/features/contact-requests/schemas";
+import {
   listingCreateBodySchema,
   listingDetailResponseSchema,
   listingParamsSchema,
@@ -75,6 +79,11 @@ export function createOpenApiDocument() {
   registry.register("ReviewsResponse", reviewsResponseSchema);
   registry.register("ReviewDetailResponse", reviewDetailResponseSchema);
   registry.register("SavedListingResponse", savedListingResponseSchema);
+  registry.register("ContactRequestCreateBody", contactRequestCreateBodySchema);
+  registry.register(
+    "ContactRequestDetailResponse",
+    contactRequestDetailResponseSchema,
+  );
 
   registry.registerPath({
     method: "post",
@@ -191,6 +200,32 @@ export function createOpenApiDocument() {
     responses: {
       200: jsonContent(reviewsResponseSchema, "Listing reviews response."),
       400: jsonContent(apiErrorResponseSchema, "Validation error response."),
+      500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/api/listings/{id}/contact-requests",
+    summary: "Create listing contact request",
+    description:
+      "Creates a structured inquiry for a signed-in renter on a listing they do not own.",
+    request: {
+      params: listingParamsSchema,
+      body: jsonRequestBody(
+        contactRequestCreateBodySchema,
+        "Contact request create payload.",
+      ),
+    },
+    responses: {
+      201: jsonContent(
+        contactRequestDetailResponseSchema,
+        "Created contact request response.",
+      ),
+      400: jsonContent(apiErrorResponseSchema, "Validation error response."),
+      401: jsonContent(apiErrorResponseSchema, "Authentication required response."),
+      403: jsonContent(apiErrorResponseSchema, "Forbidden owner-check response."),
+      404: jsonContent(apiErrorResponseSchema, "Listing not found response."),
       500: jsonContent(apiErrorResponseSchema, "Unexpected server error response."),
     },
   });

--- a/docs/superpowers/plans/2026-05-28-contact-requests.md
+++ b/docs/superpowers/plans/2026-05-28-contact-requests.md
@@ -1,0 +1,243 @@
+# Contact Requests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add stored contact requests so signed-in renters can inquire on listings and owners can review received requests from `/profile`.
+
+**Architecture:** Add a `ContactRequest` Prisma model and keep API/domain code in a new `features/contact-requests` boundary. The listing detail page renders a client form for signed-in non-owners, while `/profile` reads sent and received request summaries server-side. The first version stores inquiry data only; it does not add replies, notifications, or status transitions.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, Prisma MongoDB, Auth.js, Zod, zod-to-openapi, Vitest.
+
+---
+
+## File Structure
+
+- Modify `apps/web/prisma/schema.prisma`: add `ContactMethod` enum, `ContactRequest` model, and user/listing relations.
+- Create `apps/web/src/features/contact-requests/schemas.ts`: request body, response, list, serializer.
+- Create `apps/web/src/features/contact-requests/mutations.ts`: create request with listing existence and owner self-contact checks.
+- Create `apps/web/src/features/contact-requests/queries.ts`: read sent and received profile summaries.
+- Create `apps/web/src/features/contact-requests/components/contact-request-form.tsx`: listing detail client form.
+- Create `apps/web/src/features/contact-requests/components/contact-request-lists.tsx`: reusable profile sections.
+- Create `apps/web/src/app/api/listings/[id]/contact-requests/route.ts`: protected create endpoint.
+- Modify `apps/web/src/app/listings/[id]/page.tsx`: render the form for signed-in non-owners and keep fallback contact links.
+- Modify `apps/web/src/app/profile/page.tsx`: render sent and received request sections.
+- Modify `apps/web/src/server/api/errors.ts`: add `CONTACT_REQUEST_NOT_FOUND` only if needed; this plan does not need it.
+- Modify `apps/web/src/server/api/openapi.ts`: register contact request schemas and route docs.
+- Modify `apps/web/prisma/seed-data.mjs`: seed stable contact requests.
+- Add and update focused Vitest files for schemas, mutations, queries, route, page/profile rendering, OpenAPI, and seed data.
+
+---
+
+### Task 1: Data Model And Schemas
+
+**Files:**
+- Modify: `apps/web/prisma/schema.prisma`
+- Create: `apps/web/src/features/contact-requests/schemas.ts`
+- Create: `apps/web/src/features/contact-requests/schemas.test.ts`
+
+- [ ] **Step 1: Write failing schema tests**
+
+Create `apps/web/src/features/contact-requests/schemas.test.ts` with tests for `contactRequestCreateBodySchema`, `contactRequestResponseSchema`, and `serializeContactRequest`.
+
+Expected behavior:
+
+```ts
+expect(contactRequestCreateBodySchema.parse({
+  message: "I would like to tour this week.",
+  preferredContactMethod: "EMAIL",
+  contactEmail: "renter@example.com",
+  contactPhone: "",
+})).toEqual({
+  message: "I would like to tour this week.",
+  preferredContactMethod: "EMAIL",
+  contactEmail: "renter@example.com",
+  contactPhone: null,
+});
+```
+
+- [ ] **Step 2: Run schema tests to verify failure**
+
+Run: `cd apps/web && npm test -- src/features/contact-requests/schemas.test.ts`
+
+Expected: FAIL because the schemas module does not exist.
+
+- [ ] **Step 3: Implement Prisma model and schemas**
+
+Add `ContactMethod` enum and `ContactRequest` model to `apps/web/prisma/schema.prisma`. Add `contactRequestsSent` and `contactRequestsReceived` relations to `User`, and `contactRequests` relation to `Listing`.
+
+Create schemas with:
+
+- `contactMethodSchema = z.enum(["EMAIL", "PHONE", "ANY"])`
+- body fields: trimmed message max 2000, preferred method default `ANY`, nullable email, nullable phone
+- response fields: id, listingId, listingTitle, requesterId, requesterName, requesterEmail, ownerId, ownerName, ownerEmail, message, preferredContactMethod, contactEmail, contactPhone, createdAt, updatedAt
+- `serializeContactRequest` that accepts included listing/requester/owner data and emits strings.
+
+- [ ] **Step 4: Run schema tests to verify pass**
+
+Run: `cd apps/web && npm test -- src/features/contact-requests/schemas.test.ts`
+
+Expected: PASS.
+
+---
+
+### Task 2: Create Mutation And API Route
+
+**Files:**
+- Create: `apps/web/src/features/contact-requests/mutations.ts`
+- Create: `apps/web/src/features/contact-requests/mutations.test.ts`
+- Create: `apps/web/src/app/api/listings/[id]/contact-requests/route.ts`
+- Create: `apps/web/src/app/api/listings/[id]/contact-requests/route.test.ts`
+
+- [ ] **Step 1: Write failing mutation tests**
+
+Test that `createContactRequest`:
+
+- looks up the listing owner;
+- throws `LISTING_NOT_FOUND` when listing is missing;
+- throws `FORBIDDEN` when requester owns the listing;
+- creates a row connecting listing, requester, and owner.
+
+- [ ] **Step 2: Run mutation tests to verify failure**
+
+Run: `cd apps/web && npm test -- src/features/contact-requests/mutations.test.ts`
+
+Expected: FAIL because mutation module does not exist.
+
+- [ ] **Step 3: Implement mutation**
+
+Implement `createContactRequest(listingId, requesterId, input)` using Prisma. Return created request with listing/requester/owner included.
+
+- [ ] **Step 4: Run mutation tests to verify pass**
+
+Run: `cd apps/web && npm test -- src/features/contact-requests/mutations.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing route tests**
+
+Route tests should mock `requireCurrentUser` and `createContactRequest`, then verify:
+
+- `POST` returns `201` with `{ data: { contactRequest } }`;
+- unauthenticated and validation failures use existing helpers through the normal route pattern.
+
+- [ ] **Step 6: Implement route and verify**
+
+Run: `cd apps/web && npm test -- src/app/api/listings/[id]/contact-requests/route.test.ts`
+
+Expected: PASS.
+
+---
+
+### Task 3: Profile Queries And Sections
+
+**Files:**
+- Create: `apps/web/src/features/contact-requests/queries.ts`
+- Create: `apps/web/src/features/contact-requests/queries.test.ts`
+- Create: `apps/web/src/features/contact-requests/components/contact-request-lists.tsx`
+- Create: `apps/web/src/features/contact-requests/components/contact-request-lists.test.tsx`
+- Modify: `apps/web/src/app/profile/page.tsx`
+- Modify: `apps/web/src/app/profile/page.test.tsx`
+
+- [ ] **Step 1: Write failing query tests**
+
+Test `getReceivedContactRequestsByOwner(userId)` and `getSentContactRequestsByRequester(userId)` call Prisma with owner/requester filters, include listing/requester/owner summaries, order newest first, and return `[]` when `DATABASE_URL` is missing.
+
+- [ ] **Step 2: Implement queries and verify**
+
+Run: `cd apps/web && npm test -- src/features/contact-requests/queries.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 3: Write failing component/profile tests**
+
+Test that received and sent lists render titles, names/emails, messages, methods, and empty states. Update profile page tests to assert it requests both contact-request lists for the signed-in user.
+
+- [ ] **Step 4: Implement profile sections and verify**
+
+Run: `cd apps/web && npm test -- src/features/contact-requests/components/contact-request-lists.test.tsx src/app/profile/page.test.tsx`
+
+Expected: PASS.
+
+---
+
+### Task 4: Listing Detail Contact Form
+
+**Files:**
+- Create: `apps/web/src/features/contact-requests/components/contact-request-form.tsx`
+- Create: `apps/web/src/features/contact-requests/components/contact-request-form.test.tsx`
+- Modify: `apps/web/src/app/listings/[id]/page.tsx`
+- Modify: `apps/web/src/app/listings/[id]/page.test.tsx`
+
+- [ ] **Step 1: Write failing form and page tests**
+
+Test the form submits JSON to `/api/listings/{id}/contact-requests`, shows progress/success/error copy, and includes hidden/default contact email/phone values. Update listing detail tests to prove signed-in non-owners see the form and owners do not.
+
+- [ ] **Step 2: Implement form and page rendering**
+
+Use existing `FormFeedback`, `router.refresh()`, and current profile contact defaults when available.
+
+- [ ] **Step 3: Run form/page tests**
+
+Run: `cd apps/web && npm test -- src/features/contact-requests/components/contact-request-form.test.tsx src/app/listings/[id]/page.test.tsx`
+
+Expected: PASS.
+
+---
+
+### Task 5: Seed Data And OpenAPI
+
+**Files:**
+- Modify: `apps/web/prisma/seed-data.mjs`
+- Modify: `apps/web/prisma/seed-data.test.mjs`
+- Modify: `apps/web/src/server/api/openapi.ts`
+- Modify: `apps/web/src/server/api/openapi.test.ts`
+
+- [ ] **Step 1: Write failing seed/OpenAPI tests**
+
+Seed tests should assert `DEV_CONTACT_REQUESTS` has at least two stable requests and that `seedDevData` upserts them. OpenAPI tests should assert `/api/listings/{id}/contact-requests` exists and schemas include `ContactRequestCreateBody` and `ContactRequestDetailResponse`.
+
+- [ ] **Step 2: Implement seed and OpenAPI docs**
+
+Add `DEV_CONTACT_REQUESTS`, write-data helper, Prisma upsert loop, schema registration, and path registration.
+
+- [ ] **Step 3: Run seed/OpenAPI tests**
+
+Run: `cd apps/web && npm test -- prisma/seed-data.test.mjs src/server/api/openapi.test.ts`
+
+Expected: PASS.
+
+---
+
+### Task 6: Generate Prisma Client And Verify
+
+**Files:**
+- Generated by command: Prisma Client under `apps/web/node_modules`.
+
+- [ ] **Step 1: Format and generate Prisma Client**
+
+Run:
+
+```bash
+cd apps/web && npx prisma format
+cd apps/web && npx prisma generate
+```
+
+Expected: Prisma schema formats and client generation succeeds.
+
+- [ ] **Step 2: Run full verification**
+
+Run:
+
+```bash
+cd apps/web && npm test
+cd apps/web && npm run lint
+cd apps/web && npm run build
+```
+
+Expected: all pass. If the known local Turbopack helper-port sandbox issue appears, rerun build outside the sandbox.
+
+- [ ] **Step 3: Review diff**
+
+Run: `git status --short && git diff --stat`
+
+Expected: only contact-request feature files, schema/seed/openapi changes, and the plan/spec are present.

--- a/docs/superpowers/specs/2026-05-28-contact-requests-design.md
+++ b/docs/superpowers/specs/2026-05-28-contact-requests-design.md
@@ -1,0 +1,91 @@
+# Contact Requests Design
+
+## Goal
+
+Add a structured in-app inquiry workflow so renters can express interest in a listing and owners can review those requests from the app. This turns listing demand into app-owned data while keeping the first version smaller than messaging or notification systems.
+
+## Scope
+
+This slice covers stored contact requests, a protected create endpoint, listing-detail submission UI, profile sections for sent and received requests, local seed data, and OpenAPI documentation. It does not add real-time chat, email delivery, owner replies, moderation, or a multi-step request status workflow.
+
+## Product Behavior
+
+Signed-in non-owners can submit a contact request from a listing detail page. The form collects:
+
+- message;
+- preferred contact method;
+- contact email snapshot;
+- contact phone snapshot.
+
+The request is tied to the listing, requester, and listing owner. Owners cannot send requests to their own listings. Signed-out users see the existing sign-in path.
+
+The existing email and phone actions can remain as fallback when listing contact info exists, but the in-app form becomes the primary signed-in flow.
+
+## Profile Views
+
+`/profile` gets two lightweight sections:
+
+- **Requests received** for listing owners, grouped as a simple list with listing title, requester name/email, message, preferred contact method, and submitted date.
+- **Requests sent** for renters, showing listing title, owner name/email, message, preferred contact method, and submitted date.
+
+This keeps `/profile` as account basics plus owned activity, not renter preference storage.
+
+## Data Model
+
+Add a `ContactRequest` model with:
+
+- `id`;
+- `listingId`;
+- `listing` relation;
+- `requesterId`;
+- `requester` relation;
+- `ownerId`;
+- `owner` relation;
+- `message`;
+- `preferredContactMethod`;
+- `contactEmail`;
+- `contactPhone`;
+- `createdAt`;
+- `updatedAt`.
+
+`preferredContactMethod` should be an enum with `EMAIL`, `PHONE`, and `ANY`. Contact email and phone are snapshots so requests remain understandable even if a user later edits profile defaults.
+
+## API And Validation
+
+Add a protected `POST /api/listings/{id}/contact-requests` route. It validates the message, preferred method, and contact fields, checks the listing exists, checks the user is signed in, rejects owners contacting themselves, and stores the request.
+
+Add protected read helpers for profile usage. A separate public list endpoint is not needed in this slice; profile pages can read server-side data using feature queries.
+
+OpenAPI should document the create request body and response envelope.
+
+## Error Handling
+
+Use the existing API error envelope. Expected errors:
+
+- `AUTH_REQUIRED` for signed-out users;
+- `LISTING_NOT_FOUND` for missing listings;
+- `FORBIDDEN` when an owner contacts their own listing;
+- validation errors for missing message or invalid contact values.
+
+## Seed Data
+
+Seed at least two contact requests:
+
+- one request from the renter account to an apartment or room listing;
+- one request to the roommate listing.
+
+The seed should be idempotent and use stable IDs like the current user/listing/review/saved-listing fixtures.
+
+## Testing
+
+Use test-first changes for:
+
+- Zod schemas for contact request create and response payloads;
+- mutation behavior for create, auth/owner checks, and stable serialization;
+- profile query behavior for received and sent requests;
+- listing detail rendering of the contact form for signed-in non-owners;
+- profile rendering of sent and received request sections;
+- API route behavior and OpenAPI docs;
+- seed data shape and Prisma upserts.
+
+Full verification before completion should include `npm test`, `npm run lint`, and `npm run build` from `apps/web`.


### PR DESCRIPTION
## Summary
- Add structured contact requests from listing detail pages for signed-in renters
- Show received and sent requests on the profile page with listing links
- Add API route, shared schemas, Prisma model, seed data, and OpenAPI docs for contact requests
- Fix client success feedback so a successful `201 Created` request displays as sent instead of a false error

## Validation
- `npm test`
- `npm run lint`
- `npm run build`
- `npx prisma generate`
- `npx prisma db push`
- `npm run db:seed`

## Notes
- `gh auth status` still reports the local CLI token is invalid, so this PR was created through the GitHub connector after pushing with git.