### PR TITLE
Harden image uploads and polish auth

### DIFF
--- a/apps/web/src/app/login/page.test.tsx
+++ b/apps/web/src/app/login/page.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+import LoginPage from "@/app/login/page";
+import { auth } from "@/server/auth/auth";
+
+vi.mock("@/server/auth/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`redirect:${url}`);
+  }),
+}));
+
+function includesText(node: unknown, text: string): boolean {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node).includes(text);
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  return Object.values(node).some((value) => includesText(value, text));
+}
+
+describe("LoginPage", () => {
+  it("redirects signed-in users to the safe callback URL", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "507f1f77bcf86cd799439099",
+        email: "renter@example.com",
+      },
+      expires: "2026-06-01T00:00:00.000Z",
+    });
+
+    await expect(
+      LoginPage({
+        searchParams: Promise.resolve({ callbackUrl: "/profile" }),
+      }),
+    ).rejects.toThrow("redirect:/profile");
+  });
+
+  it("renders the login form for signed-out users", async () => {
+    vi.mocked(auth).mockResolvedValue(null);
+
+    const page = await LoginPage({
+      searchParams: Promise.resolve({ callbackUrl: "/profile" }),
+    });
+
+    expect(includesText(page, "Sign in to AllApartments")).toBe(true);
+    const form = (page.props.children as unknown[]).at(-1) as {
+      props: { callbackUrl?: string };
+    };
+    expect(form.props.callbackUrl).toBe("/profile");
+  });
+});

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,5 +1,8 @@
+import { redirect } from "next/navigation";
+
 import { resolveAuthCallbackUrl } from "@/features/auth/callback-url";
 import { LoginForm } from "@/features/auth/components/login-form";
+import { auth } from "@/server/auth/auth";
 
 type LoginPageProps = {
   searchParams: Promise<{
@@ -9,6 +12,11 @@ type LoginPageProps = {
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const callbackUrl = resolveAuthCallbackUrl((await searchParams).callbackUrl);
+  const session = await auth();
+
+  if (session?.user?.id) {
+    redirect(callbackUrl);
+  }
 
   return (
     <main className="mx-auto w-full max-w-md px-6 py-12">

--- a/apps/web/src/app/register/page.test.tsx
+++ b/apps/web/src/app/register/page.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+import RegisterPage from "@/app/register/page";
+import { auth } from "@/server/auth/auth";
+
+vi.mock("@/server/auth/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`redirect:${url}`);
+  }),
+}));
+
+function includesText(node: unknown, text: string): boolean {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node).includes(text);
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  return Object.values(node).some((value) => includesText(value, text));
+}
+
+describe("RegisterPage", () => {
+  it("redirects signed-in users to the safe callback URL", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: {
+        id: "507f1f77bcf86cd799439099",
+        email: "renter@example.com",
+      },
+      expires: "2026-06-01T00:00:00.000Z",
+    });
+
+    await expect(
+      RegisterPage({
+        searchParams: Promise.resolve({ callbackUrl: "/profile" }),
+      }),
+    ).rejects.toThrow("redirect:/profile");
+  });
+
+  it("renders the registration form for signed-out users", async () => {
+    vi.mocked(auth).mockResolvedValue(null);
+
+    const page = await RegisterPage({
+      searchParams: Promise.resolve({ callbackUrl: "/profile" }),
+    });
+
+    expect(includesText(page, "Join AllApartments")).toBe(true);
+    const form = (page.props.children as unknown[]).at(-1) as {
+      props: { callbackUrl?: string };
+    };
+    expect(form.props.callbackUrl).toBe("/profile");
+  });
+});

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -1,5 +1,8 @@
+import { redirect } from "next/navigation";
+
 import { resolveAuthCallbackUrl } from "@/features/auth/callback-url";
 import { RegisterForm } from "@/features/auth/components/register-form";
+import { auth } from "@/server/auth/auth";
 
 type RegisterPageProps = {
   searchParams: Promise<{
@@ -9,6 +12,11 @@ type RegisterPageProps = {
 
 export default async function RegisterPage({ searchParams }: RegisterPageProps) {
   const callbackUrl = resolveAuthCallbackUrl((await searchParams).callbackUrl);
+  const session = await auth();
+
+  if (session?.user?.id) {
+    redirect(callbackUrl);
+  }
 
   return (
     <main className="mx-auto w-full max-w-md px-6 py-12">

--- a/apps/web/src/features/auth/components/login-form.test.tsx
+++ b/apps/web/src/features/auth/components/login-form.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { submitLogin } from "@/features/auth/components/login-form";
+
+describe("submitLogin", () => {
+  it("returns success when credentials sign-in succeeds", async () => {
+    const signInFn = vi.fn().mockResolvedValue({ error: null });
+
+    await expect(
+      submitLogin({
+        callbackUrl: "/profile",
+        email: "renter@example.com",
+        password: "Password1",
+        signInFn,
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("maps credentials errors to the invalid credentials message", async () => {
+    const signInFn = vi.fn().mockResolvedValue({ error: "CredentialsSignin" });
+
+    await expect(
+      submitLogin({
+        callbackUrl: "/profile",
+        email: "renter@example.com",
+        password: "wrong",
+        signInFn,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "Email or password is incorrect.",
+    });
+  });
+
+  it("maps thrown sign-in failures to a retry message", async () => {
+    const signInFn = vi.fn().mockRejectedValue(new Error("Network failure"));
+
+    await expect(
+      submitLogin({
+        callbackUrl: "/profile",
+        email: "renter@example.com",
+        password: "Password1",
+        signInFn,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "Could not sign in. Please try again.",
+    });
+  });
+});

--- a/apps/web/src/features/auth/components/login-form.tsx
+++ b/apps/web/src/features/auth/components/login-form.tsx
@@ -11,6 +11,54 @@ type LoginFormProps = {
   callbackUrl: string;
 };
 
+type SignInFn = typeof signIn;
+
+type SubmitLoginOptions = {
+  callbackUrl: string;
+  email: FormDataEntryValue | null;
+  password: FormDataEntryValue | null;
+  signInFn?: SignInFn;
+};
+
+type SubmitLoginResult =
+  | {
+      ok: true;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export async function submitLogin({
+  callbackUrl,
+  email,
+  password,
+  signInFn = signIn,
+}: SubmitLoginOptions): Promise<SubmitLoginResult> {
+  try {
+    const result = await signInFn("credentials", {
+      email,
+      password,
+      redirect: false,
+      callbackUrl,
+    });
+
+    if (result?.error) {
+      return {
+        ok: false,
+        error: "Email or password is incorrect.",
+      };
+    }
+
+    return { ok: true };
+  } catch {
+    return {
+      ok: false,
+      error: "Could not sign in. Please try again.",
+    };
+  }
+}
+
 export function LoginForm({ callbackUrl }: LoginFormProps) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
@@ -24,18 +72,17 @@ export function LoginForm({ callbackUrl }: LoginFormProps) {
     setIsSubmitting(true);
 
     const formData = new FormData(event.currentTarget);
-    const result = await signIn("credentials", {
+    const result = await submitLogin({
+      callbackUrl,
       email: formData.get("email"),
       password: formData.get("password"),
-      redirect: false,
-      callbackUrl,
     });
 
     setIsSubmitting(false);
 
-    if (result?.error) {
+    if (!result.ok) {
       setNotice(null);
-      setError("Email or password is incorrect.");
+      setError(result.error);
       return;
     }
 
@@ -65,6 +112,7 @@ export function LoginForm({ callbackUrl }: LoginFormProps) {
           type="email"
           required
           autoComplete="email"
+          disabled={isSubmitting}
           className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
         />
       </div>
@@ -79,6 +127,7 @@ export function LoginForm({ callbackUrl }: LoginFormProps) {
           type="password"
           required
           autoComplete="current-password"
+          disabled={isSubmitting}
           className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
         />
       </div>

--- a/apps/web/src/features/auth/components/register-form.test.tsx
+++ b/apps/web/src/features/auth/components/register-form.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { submitRegistration } from "@/features/auth/components/register-form";
+
+describe("submitRegistration", () => {
+  it("returns success after registering and signing in", async () => {
+    const fetcher = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));
+    const signInFn = vi.fn().mockResolvedValue({ error: null });
+
+    await expect(
+      submitRegistration({
+        callbackUrl: "/profile",
+        email: "renter@example.com",
+        fetcher,
+        name: "Renter One",
+        password: "Password1",
+        signInFn,
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("uses API error messages when registration fails", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      Response.json(
+        { error: { message: "An account with this email already exists." } },
+        { status: 409 },
+      ),
+    );
+    const signInFn = vi.fn();
+
+    await expect(
+      submitRegistration({
+        callbackUrl: "/profile",
+        email: "renter@example.com",
+        fetcher,
+        name: "Renter One",
+        password: "Password1",
+        signInFn,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "An account with this email already exists.",
+    });
+    expect(signInFn).not.toHaveBeenCalled();
+  });
+
+  it("reports manual sign-in when automatic sign-in fails", async () => {
+    const fetcher = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));
+    const signInFn = vi.fn().mockResolvedValue({ error: "CredentialsSignin" });
+
+    await expect(
+      submitRegistration({
+        callbackUrl: "/profile",
+        email: "renter@example.com",
+        fetcher,
+        name: "Renter One",
+        password: "Password1",
+        signInFn,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "Account created, but sign-in failed. Please sign in manually.",
+    });
+  });
+
+  it("maps thrown registration failures to a retry message", async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error("Network failure"));
+    const signInFn = vi.fn();
+
+    await expect(
+      submitRegistration({
+        callbackUrl: "/profile",
+        email: "renter@example.com",
+        fetcher,
+        name: "Renter One",
+        password: "Password1",
+        signInFn,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "Could not create your account. Please try again.",
+    });
+  });
+});

--- a/apps/web/src/features/auth/components/register-form.tsx
+++ b/apps/web/src/features/auth/components/register-form.tsx
@@ -22,6 +22,77 @@ type RegisterFormProps = {
   callbackUrl: string;
 };
 
+type SignInFn = typeof signIn;
+
+type SubmitRegistrationOptions = {
+  callbackUrl: string;
+  email: FormDataEntryValue | null;
+  fetcher?: typeof fetch;
+  name: FormDataEntryValue | null;
+  password: FormDataEntryValue | null;
+  signInFn?: SignInFn;
+};
+
+type SubmitRegistrationResult =
+  | {
+      ok: true;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export async function submitRegistration({
+  callbackUrl,
+  email,
+  fetcher = fetch,
+  name,
+  password,
+  signInFn = signIn,
+}: SubmitRegistrationOptions): Promise<SubmitRegistrationResult> {
+  try {
+    const response = await fetcher("/api/auth/register", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name,
+        email,
+        password,
+      }),
+    });
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: await readErrorMessage(response),
+      };
+    }
+
+    const result = await signInFn("credentials", {
+      email,
+      password,
+      redirect: false,
+      callbackUrl,
+    });
+
+    if (result?.error) {
+      return {
+        ok: false,
+        error: "Account created, but sign-in failed. Please sign in manually.",
+      };
+    }
+
+    return { ok: true };
+  } catch {
+    return {
+      ok: false,
+      error: "Could not create your account. Please try again.",
+    };
+  }
+}
+
 export function RegisterForm({ callbackUrl }: RegisterFormProps) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
@@ -35,40 +106,18 @@ export function RegisterForm({ callbackUrl }: RegisterFormProps) {
     setIsSubmitting(true);
 
     const formData = new FormData(event.currentTarget);
-    const email = formData.get("email");
-    const password = formData.get("password");
-
-    const response = await fetch("/api/auth/register", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name: formData.get("name"),
-        email,
-        password,
-      }),
-    });
-
-    if (!response.ok) {
-      setNotice(null);
-      setError(await readErrorMessage(response));
-      setIsSubmitting(false);
-      return;
-    }
-
-    const result = await signIn("credentials", {
-      email,
-      password,
-      redirect: false,
+    const result = await submitRegistration({
       callbackUrl,
+      email: formData.get("email"),
+      name: formData.get("name"),
+      password: formData.get("password"),
     });
 
     setIsSubmitting(false);
 
-    if (result?.error) {
+    if (!result.ok) {
       setNotice(null);
-      setError("Account created, but sign-in failed. Please sign in manually.");
+      setError(result.error);
       return;
     }
 
@@ -98,6 +147,7 @@ export function RegisterForm({ callbackUrl }: RegisterFormProps) {
           required
           minLength={2}
           autoComplete="name"
+          disabled={isSubmitting}
           className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
         />
       </div>
@@ -112,6 +162,7 @@ export function RegisterForm({ callbackUrl }: RegisterFormProps) {
           type="email"
           required
           autoComplete="email"
+          disabled={isSubmitting}
           className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
         />
       </div>
@@ -127,6 +178,7 @@ export function RegisterForm({ callbackUrl }: RegisterFormProps) {
           required
           minLength={8}
           autoComplete="new-password"
+          disabled={isSubmitting}
           className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
         />
       </div>

--- a/apps/web/src/features/listings/components/listing-create-form.test.tsx
+++ b/apps/web/src/features/listings/components/listing-create-form.test.tsx
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { RoommateFitFields } from "@/features/listings/components/listing-create-form";
+import {
+  filterListingImageFiles,
+  RoommateFitFields,
+} from "@/features/listings/components/listing-create-form";
 
 function includesText(
   node: unknown,
@@ -39,5 +42,49 @@ describe("RoommateFitFields", () => {
     expect(includesText(fields, "Roommate fit")).toBe(true);
     expect(includesText(fields, "Preferred gender")).toBe(true);
     expect(includesText(fields, "Graduate students preferred")).toBe(true);
+  });
+});
+
+describe("filterListingImageFiles", () => {
+  it("keeps supported images within the size limit", () => {
+    const png = new File(["image"], "room.png", { type: "image/png" });
+    const jpeg = new File(["image"], "room.jpg", { type: "image/jpeg" });
+
+    expect(filterListingImageFiles([png, jpeg], 0)).toEqual({
+      files: [png, jpeg],
+      error: null,
+    });
+  });
+
+  it("rejects unsupported image types", () => {
+    const gif = new File(["image"], "room.gif", { type: "image/gif" });
+
+    expect(filterListingImageFiles([gif], 0)).toEqual({
+      files: [],
+      error: "Only JPEG, PNG, and WebP images are supported.",
+    });
+  });
+
+  it("rejects oversized images", () => {
+    const oversized = new File(
+      [new Uint8Array(2 * 1024 * 1024 + 1)],
+      "large.png",
+      { type: "image/png" },
+    );
+
+    expect(filterListingImageFiles([oversized], 0)).toEqual({
+      files: [],
+      error: "Each image must be 2 MB or smaller.",
+    });
+  });
+
+  it("limits files to the remaining image slots", () => {
+    const first = new File(["image"], "one.png", { type: "image/png" });
+    const second = new File(["image"], "two.png", { type: "image/png" });
+
+    expect(filterListingImageFiles([first, second], 4)).toEqual({
+      files: [first],
+      error: "Only 1 more image(s) can be added.",
+    });
   });
 });

--- a/apps/web/src/features/listings/components/listing-create-form.tsx
+++ b/apps/web/src/features/listings/components/listing-create-form.tsx
@@ -4,7 +4,12 @@ import { useRouter } from "next/navigation";
 import { useRef, useState, type DragEvent, type FormEvent } from "react";
 
 import { createListingPayloadFromFormData } from "@/features/listings/form-payload";
-import type { ListingCreateInput } from "@/features/listings/schemas";
+import {
+  LISTING_IMAGE_ACCEPTED_MIME_TYPES,
+  LISTING_IMAGE_MAX_BYTES,
+  LISTING_IMAGE_MAX_COUNT,
+  type ListingCreateInput,
+} from "@/features/listings/schemas";
 import { FormFeedback } from "@/features/ui/form-feedback";
 
 type ApiErrorBody = {
@@ -52,7 +57,9 @@ type ListingCreateFormProps = {
   defaultContactPhone?: string | null;
 };
 
-const MAX_IMAGES = 5;
+const LISTING_IMAGE_ACCEPT = LISTING_IMAGE_ACCEPTED_MIME_TYPES.join(",");
+const LISTING_IMAGE_TYPE_ERROR = "Only JPEG, PNG, and WebP images are supported.";
+const LISTING_IMAGE_SIZE_ERROR = "Each image must be 2 MB or smaller.";
 
 function toDateInputValue(value: Date | string | null | undefined) {
   if (!value) {
@@ -69,6 +76,45 @@ function readFileAsDataUrl(file: File) {
     reader.addEventListener("error", () => reject(reader.error));
     reader.readAsDataURL(file);
   });
+}
+
+export function filterListingImageFiles(
+  files: FileList | File[],
+  currentImageCount: number,
+) {
+  const acceptedTypes = new Set<string>(LISTING_IMAGE_ACCEPTED_MIME_TYPES);
+  const slotsAvailable = LISTING_IMAGE_MAX_COUNT - currentImageCount;
+
+  if (slotsAvailable <= 0) {
+    return {
+      files: [],
+      error: `You can upload up to ${LISTING_IMAGE_MAX_COUNT} images.`,
+    };
+  }
+
+  let error: string | null = null;
+  const validFiles = Array.from(files).filter((file) => {
+    if (!acceptedTypes.has(file.type)) {
+      error ??= LISTING_IMAGE_TYPE_ERROR;
+      return false;
+    }
+
+    if (file.size > LISTING_IMAGE_MAX_BYTES) {
+      error ??= LISTING_IMAGE_SIZE_ERROR;
+      return false;
+    }
+
+    return true;
+  });
+
+  if (validFiles.length > slotsAvailable) {
+    error = `Only ${slotsAvailable} more image(s) can be added.`;
+  }
+
+  return {
+    files: validFiles.slice(0, slotsAvailable),
+    error,
+  };
 }
 
 type RoommateFitFieldsProps = {
@@ -219,23 +265,17 @@ export function ListingCreateForm({
     setError(null);
     setNotice(null);
 
-    const imageFiles = Array.from(files).filter((file) =>
-      file.type.startsWith("image/"),
-    );
-    const slotsAvailable = MAX_IMAGES - imageUrls.length;
+    const result = filterListingImageFiles(files, imageUrls.length);
 
-    if (slotsAvailable <= 0) {
-      setError(`You can upload up to ${MAX_IMAGES} images.`);
+    if (result.error) {
+      setError(result.error);
+    }
+
+    if (result.files.length === 0) {
       return;
     }
 
-    if (imageFiles.length > slotsAvailable) {
-      setError(`Only ${slotsAvailable} more image(s) can be added.`);
-    }
-
-    const nextImages = await Promise.all(
-      imageFiles.slice(0, slotsAvailable).map(readFileAsDataUrl),
-    );
+    const nextImages = await Promise.all(result.files.map(readFileAsDataUrl));
 
     setImageUrls((current) => [...current, ...nextImages]);
   }
@@ -580,7 +620,7 @@ export function ListingCreateForm({
         <div className="flex items-center justify-between gap-3">
           <p className="text-sm font-medium text-zinc-800">Images</p>
           <p className="text-xs text-zinc-500">
-            {imageUrls.length}/{MAX_IMAGES}
+            {imageUrls.length}/{LISTING_IMAGE_MAX_COUNT}
           </p>
         </div>
         <div
@@ -591,7 +631,7 @@ export function ListingCreateForm({
           <input
             ref={fileInputRef}
             type="file"
-            accept="image/*"
+            accept={LISTING_IMAGE_ACCEPT}
             multiple
             className="hidden"
             onChange={(event) => {

--- a/apps/web/src/features/listings/schemas.test.ts
+++ b/apps/web/src/features/listings/schemas.test.ts
@@ -140,17 +140,55 @@ describe("listing API schemas", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("accepts uploaded image data urls for listing writes", () => {
+  it("accepts hosted image URLs and supported data URLs for listing writes", () => {
     const parsed = listingCreateBodySchema.safeParse({
       title: "Sunny room",
       type: "ROOM",
       description: "Private room near campus.",
       rent: 850,
       petPolicy: "PETS_ALLOWED",
-      imageUrls: ["data:image/png;base64,abc123"],
+      imageUrls: [
+        "https://example.com/listing-photo.jpg",
+        "data:image/jpeg;base64,abc123",
+        "data:image/png;base64,def456",
+        "data:image/webp;base64,ghi789",
+      ],
     });
 
     expect(parsed.success).toBe(true);
+  });
+
+  it("rejects unsupported data URL image types for listing writes", () => {
+    const parsed = listingCreateBodySchema.safeParse({
+      title: "Sunny room",
+      type: "ROOM",
+      description: "Private room near campus.",
+      rent: 850,
+      petPolicy: "PETS_ALLOWED",
+      imageUrls: ["data:image/gif;base64,abc123"],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects more than five images for listing writes", () => {
+    const parsed = listingCreateBodySchema.safeParse({
+      title: "Sunny room",
+      type: "ROOM",
+      description: "Private room near campus.",
+      rent: 850,
+      petPolicy: "PETS_ALLOWED",
+      imageUrls: [
+        "data:image/png;base64,one",
+        "data:image/png;base64,two",
+        "data:image/png;base64,three",
+        "data:image/png;base64,four",
+        "data:image/png;base64,five",
+        "data:image/png;base64,six",
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
   });
 
   it("accepts optional contact fields for listing writes", () => {

--- a/apps/web/src/features/listings/schemas.ts
+++ b/apps/web/src/features/listings/schemas.ts
@@ -12,9 +12,25 @@ export const petPolicySchema = z.enum([
   "DOGS_ONLY",
   "PETS_ALLOWED",
 ]);
+export const LISTING_IMAGE_MAX_COUNT = 5;
+export const LISTING_IMAGE_MAX_BYTES = 2 * 1024 * 1024;
+export const LISTING_IMAGE_ACCEPTED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+] as const;
+const listingImageDataUrlPattern = new RegExp(
+  `^data:(${LISTING_IMAGE_ACCEPTED_MIME_TYPES.join("|")});base64,`,
+);
+const hostedImageUrlSchema = z.string().url().startsWith("https://");
 const imageUrlSchema = z
   .string()
-  .url()
+  .refine(
+    (value) =>
+      hostedImageUrlSchema.safeParse(value).success ||
+      listingImageDataUrlPattern.test(value),
+    "Image must be an HTTPS URL or a supported JPEG, PNG, or WebP data URL.",
+  )
   .openapi({ example: "https://example.com/listing-photo.jpg" });
 
 const nullableEmailSchema = z
@@ -133,6 +149,7 @@ export const listingCreateBodySchema = z.object({
   amenities: z.array(z.string().trim().min(1)).default([]),
   imageUrls: z
     .array(imageUrlSchema)
+    .max(LISTING_IMAGE_MAX_COUNT)
     .default([])
     .openapi({ example: ["https://example.com/listing-photo.jpg"] }),
   roommateCount: nullableRoommateCountSchema.default(null),
@@ -164,6 +181,7 @@ export const listingUpdateBodySchema = z
     amenities: z.array(z.string().trim().min(1)).optional(),
     imageUrls: z
       .array(imageUrlSchema)
+      .max(LISTING_IMAGE_MAX_COUNT)
       .optional()
       .openapi({ example: ["https://example.com/listing-photo.jpg"] }),
     roommateCount: nullableRoommateCountSchema.optional(),

--- a/docs/superpowers/plans/2026-05-28-auth-polish.md
+++ b/docs/superpowers/plans/2026-05-28-auth-polish.md
@@ -31,11 +31,11 @@
 - Test: `apps/web/src/app/login/page.test.tsx`
 - Test: `apps/web/src/app/register/page.test.tsx`
 
-- [ ] Write failing page tests for signed-in redirects and signed-out render behavior.
-- [ ] Run `npm test -- login/page.test.tsx register/page.test.tsx` and confirm redirect tests fail.
-- [ ] Import `auth()` and `redirect()` in both pages.
-- [ ] Resolve the callback URL first, then redirect signed-in users to that safe callback URL.
-- [ ] Run `npm test -- login/page.test.tsx register/page.test.tsx` and confirm it passes.
+- [x] Write failing page tests for signed-in redirects and signed-out render behavior.
+- [x] Run `npm test -- login/page.test.tsx register/page.test.tsx` and confirm redirect tests fail.
+- [x] Import `auth()` and `redirect()` in both pages.
+- [x] Resolve the callback URL first, then redirect signed-in users to that safe callback URL.
+- [x] Run `npm test -- login/page.test.tsx register/page.test.tsx` and confirm it passes.
 
 ### Task 2: Login Form Failure Polish
 
@@ -43,11 +43,11 @@
 - Modify: `apps/web/src/features/auth/components/login-form.tsx`
 - Test: `apps/web/src/features/auth/components/login-form.test.tsx`
 
-- [ ] Write failing tests for a `submitLogin` helper that returns success, invalid-credentials error, and unexpected retry error results.
-- [ ] Run `npm test -- login-form.test.tsx` and confirm the helper tests fail.
-- [ ] Export `submitLogin({ email, password, callbackUrl, signInFn })`.
-- [ ] Update `LoginForm` to use the helper, catch failures, and disable inputs while submitting.
-- [ ] Run `npm test -- login-form.test.tsx` and confirm it passes.
+- [x] Write failing tests for a `submitLogin` helper that returns success, invalid-credentials error, and unexpected retry error results.
+- [x] Run `npm test -- login-form.test.tsx` and confirm the helper tests fail.
+- [x] Export `submitLogin({ email, password, callbackUrl, signInFn })`.
+- [x] Update `LoginForm` to use the helper, catch failures, and disable inputs while submitting.
+- [x] Run `npm test -- login-form.test.tsx` and confirm it passes.
 
 ### Task 3: Register Form Failure Polish
 
@@ -55,19 +55,18 @@
 - Modify: `apps/web/src/features/auth/components/register-form.tsx`
 - Test: `apps/web/src/features/auth/components/register-form.test.tsx`
 
-- [ ] Write failing tests for a `submitRegistration` helper that returns success, API message errors, sign-in-after-registration errors, and network retry errors.
-- [ ] Run `npm test -- register-form.test.tsx` and confirm the helper tests fail.
-- [ ] Export `submitRegistration({ name, email, password, callbackUrl, fetcher, signInFn })`.
-- [ ] Update `RegisterForm` to use the helper, catch failures, and disable inputs while submitting.
-- [ ] Run `npm test -- register-form.test.tsx` and confirm it passes.
+- [x] Write failing tests for a `submitRegistration` helper that returns success, API message errors, sign-in-after-registration errors, and network retry errors.
+- [x] Run `npm test -- register-form.test.tsx` and confirm the helper tests fail.
+- [x] Export `submitRegistration({ name, email, password, callbackUrl, fetcher, signInFn })`.
+- [x] Update `RegisterForm` to use the helper, catch failures, and disable inputs while submitting.
+- [x] Run `npm test -- register-form.test.tsx` and confirm it passes.
 
 ### Task 4: Full Verification
 
 **Files:**
 - Verify current branch only.
 
-- [ ] Run `npm test`.
-- [ ] Run `npm run lint`.
-- [ ] Run `npm run build`.
-- [ ] Commit with `git commit -m "Polish credentials auth flow"`.
-
+- [x] Run `npm test`.
+- [x] Run `npm run lint`.
+- [x] Run `npm run build`.
+- [x] Commit with `git commit -m "Polish credentials auth flow"`.

--- a/docs/superpowers/plans/2026-05-28-auth-polish.md
+++ b/docs/superpowers/plans/2026-05-28-auth-polish.md
@@ -1,0 +1,73 @@
+# Auth Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Polish the existing local credentials auth flow with signed-in redirects, safer failure handling, and submitting-state form controls.
+
+**Architecture:** Keep Auth.js credentials and existing callback URL validation. Add server-side redirects to auth pages, and extract small client submission helpers so login/register failure behavior can be tested without a DOM harness.
+
+**Tech Stack:** Next.js App Router, Auth.js, React, TypeScript, Vitest.
+
+---
+
+## File Structure
+
+- Modify `apps/web/src/app/login/page.tsx`: read session with `auth()` and redirect signed-in users to the sanitized callback URL.
+- Create `apps/web/src/app/login/page.test.tsx`: verify signed-in redirect and signed-out render path.
+- Modify `apps/web/src/app/register/page.tsx`: read session with `auth()` and redirect signed-in users to the sanitized callback URL.
+- Create `apps/web/src/app/register/page.test.tsx`: verify signed-in redirect and signed-out render path.
+- Modify `apps/web/src/features/auth/components/login-form.tsx`: export a login submission helper, catch sign-in exceptions, and disable fields while submitting.
+- Create `apps/web/src/features/auth/components/login-form.test.tsx`: verify helper result mapping.
+- Modify `apps/web/src/features/auth/components/register-form.tsx`: export a registration submission helper, catch fetch/sign-in exceptions, and disable fields while submitting.
+- Create `apps/web/src/features/auth/components/register-form.test.tsx`: verify helper result mapping.
+
+## Tasks
+
+### Task 1: Signed-in Auth Page Redirects
+
+**Files:**
+- Modify: `apps/web/src/app/login/page.tsx`
+- Modify: `apps/web/src/app/register/page.tsx`
+- Test: `apps/web/src/app/login/page.test.tsx`
+- Test: `apps/web/src/app/register/page.test.tsx`
+
+- [ ] Write failing page tests for signed-in redirects and signed-out render behavior.
+- [ ] Run `npm test -- login/page.test.tsx register/page.test.tsx` and confirm redirect tests fail.
+- [ ] Import `auth()` and `redirect()` in both pages.
+- [ ] Resolve the callback URL first, then redirect signed-in users to that safe callback URL.
+- [ ] Run `npm test -- login/page.test.tsx register/page.test.tsx` and confirm it passes.
+
+### Task 2: Login Form Failure Polish
+
+**Files:**
+- Modify: `apps/web/src/features/auth/components/login-form.tsx`
+- Test: `apps/web/src/features/auth/components/login-form.test.tsx`
+
+- [ ] Write failing tests for a `submitLogin` helper that returns success, invalid-credentials error, and unexpected retry error results.
+- [ ] Run `npm test -- login-form.test.tsx` and confirm the helper tests fail.
+- [ ] Export `submitLogin({ email, password, callbackUrl, signInFn })`.
+- [ ] Update `LoginForm` to use the helper, catch failures, and disable inputs while submitting.
+- [ ] Run `npm test -- login-form.test.tsx` and confirm it passes.
+
+### Task 3: Register Form Failure Polish
+
+**Files:**
+- Modify: `apps/web/src/features/auth/components/register-form.tsx`
+- Test: `apps/web/src/features/auth/components/register-form.test.tsx`
+
+- [ ] Write failing tests for a `submitRegistration` helper that returns success, API message errors, sign-in-after-registration errors, and network retry errors.
+- [ ] Run `npm test -- register-form.test.tsx` and confirm the helper tests fail.
+- [ ] Export `submitRegistration({ name, email, password, callbackUrl, fetcher, signInFn })`.
+- [ ] Update `RegisterForm` to use the helper, catch failures, and disable inputs while submitting.
+- [ ] Run `npm test -- register-form.test.tsx` and confirm it passes.
+
+### Task 4: Full Verification
+
+**Files:**
+- Verify current branch only.
+
+- [ ] Run `npm test`.
+- [ ] Run `npm run lint`.
+- [ ] Run `npm run build`.
+- [ ] Commit with `git commit -m "Polish credentials auth flow"`.
+

--- a/docs/superpowers/plans/2026-05-28-image-upload-hardening.md
+++ b/docs/superpowers/plans/2026-05-28-image-upload-hardening.md
@@ -26,12 +26,12 @@
 - Modify: `apps/web/src/features/listings/schemas.ts`
 - Test: `apps/web/src/features/listings/schemas.test.ts`
 
-- [ ] Add failing tests that assert `listingCreateBodySchema` accepts HTTPS URLs and JPEG/PNG/WebP data URLs, rejects `data:image/gif`, and rejects six images.
-- [ ] Run `npm test -- schemas.test.ts` and confirm the new tests fail.
-- [ ] Export constants: `LISTING_IMAGE_MAX_COUNT`, `LISTING_IMAGE_MAX_BYTES`, `LISTING_IMAGE_ACCEPTED_MIME_TYPES`.
-- [ ] Replace the loose image URL schema with a schema that accepts `https://...` URLs and data URLs whose MIME type is one of the accepted image MIME types.
-- [ ] Apply `.max(LISTING_IMAGE_MAX_COUNT)` to create and update `imageUrls` arrays.
-- [ ] Run `npm test -- schemas.test.ts` and confirm it passes.
+- [x] Add failing tests that assert `listingCreateBodySchema` accepts HTTPS URLs and JPEG/PNG/WebP data URLs, rejects `data:image/gif`, and rejects six images.
+- [x] Run `npm test -- schemas.test.ts` and confirm the new tests fail.
+- [x] Export constants: `LISTING_IMAGE_MAX_COUNT`, `LISTING_IMAGE_MAX_BYTES`, `LISTING_IMAGE_ACCEPTED_MIME_TYPES`.
+- [x] Replace the loose image URL schema with a schema that accepts `https://...` URLs and data URLs whose MIME type is one of the accepted image MIME types.
+- [x] Apply `.max(LISTING_IMAGE_MAX_COUNT)` to create and update `imageUrls` arrays.
+- [x] Run `npm test -- schemas.test.ts` and confirm it passes.
 
 ### Task 2: Client File Filtering
 
@@ -39,21 +39,20 @@
 - Modify: `apps/web/src/features/listings/components/listing-create-form.tsx`
 - Test: `apps/web/src/features/listings/components/listing-create-form.test.tsx`
 
-- [ ] Add failing tests for an exported helper that filters selected image files by type, size, and remaining slots.
-- [ ] Run `npm test -- listing-create-form.test.tsx` and confirm the new tests fail.
-- [ ] Import the shared image constants from `schemas.ts`.
-- [ ] Export `filterListingImageFiles(files, currentImageCount)` from `listing-create-form.tsx`.
-- [ ] Use the helper in `addFiles` before calling `readFileAsDataUrl`.
-- [ ] Change the file input `accept` attribute to the explicit accepted MIME list.
-- [ ] Run `npm test -- listing-create-form.test.tsx` and confirm it passes.
+- [x] Add failing tests for an exported helper that filters selected image files by type, size, and remaining slots.
+- [x] Run `npm test -- listing-create-form.test.tsx` and confirm the new tests fail.
+- [x] Import the shared image constants from `schemas.ts`.
+- [x] Export `filterListingImageFiles(files, currentImageCount)` from `listing-create-form.tsx`.
+- [x] Use the helper in `addFiles` before calling `readFileAsDataUrl`.
+- [x] Change the file input `accept` attribute to the explicit accepted MIME list.
+- [x] Run `npm test -- listing-create-form.test.tsx` and confirm it passes.
 
 ### Task 3: Full Verification
 
 **Files:**
 - Verify current branch only.
 
-- [ ] Run `npm test`.
-- [ ] Run `npm run lint`.
-- [ ] Run `npm run build`.
+- [x] Run `npm test`.
+- [x] Run `npm run lint`.
+- [x] Run `npm run build`.
 - [ ] Commit the implementation with `git commit -m "Harden local image uploads"`.
-

--- a/docs/superpowers/plans/2026-05-28-image-upload-hardening.md
+++ b/docs/superpowers/plans/2026-05-28-image-upload-hardening.md
@@ -1,0 +1,59 @@
+# Image Upload Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden local listing image uploads with MIME, count, and size validation without adding external storage.
+
+**Architecture:** Keep the existing data URL storage model, but centralize image limits in listing schemas and listing form helpers. The API schema remains the source of truth, while the client rejects bad files before reading them into memory.
+
+**Tech Stack:** Next.js, React, TypeScript, Zod, Vitest.
+
+---
+
+## File Structure
+
+- Modify `apps/web/src/features/listings/schemas.ts` to export image limits and enforce valid HTTPS URLs or accepted image data URLs with a max count.
+- Modify `apps/web/src/features/listings/schemas.test.ts` to cover accepted image values, unsupported data URL media types, and count overflow.
+- Modify `apps/web/src/features/listings/components/listing-create-form.tsx` to use exported limits, validate selected files before `FileReader`, and show deterministic error messages.
+- Modify `apps/web/src/features/listings/components/listing-create-form.test.tsx` to test the pure file-filtering helper.
+- Create or update `docs/superpowers/plans/2026-05-28-image-upload-hardening.md` for implementation tracking.
+
+## Tasks
+
+### Task 1: Schema Hardening
+
+**Files:**
+- Modify: `apps/web/src/features/listings/schemas.ts`
+- Test: `apps/web/src/features/listings/schemas.test.ts`
+
+- [ ] Add failing tests that assert `listingCreateBodySchema` accepts HTTPS URLs and JPEG/PNG/WebP data URLs, rejects `data:image/gif`, and rejects six images.
+- [ ] Run `npm test -- schemas.test.ts` and confirm the new tests fail.
+- [ ] Export constants: `LISTING_IMAGE_MAX_COUNT`, `LISTING_IMAGE_MAX_BYTES`, `LISTING_IMAGE_ACCEPTED_MIME_TYPES`.
+- [ ] Replace the loose image URL schema with a schema that accepts `https://...` URLs and data URLs whose MIME type is one of the accepted image MIME types.
+- [ ] Apply `.max(LISTING_IMAGE_MAX_COUNT)` to create and update `imageUrls` arrays.
+- [ ] Run `npm test -- schemas.test.ts` and confirm it passes.
+
+### Task 2: Client File Filtering
+
+**Files:**
+- Modify: `apps/web/src/features/listings/components/listing-create-form.tsx`
+- Test: `apps/web/src/features/listings/components/listing-create-form.test.tsx`
+
+- [ ] Add failing tests for an exported helper that filters selected image files by type, size, and remaining slots.
+- [ ] Run `npm test -- listing-create-form.test.tsx` and confirm the new tests fail.
+- [ ] Import the shared image constants from `schemas.ts`.
+- [ ] Export `filterListingImageFiles(files, currentImageCount)` from `listing-create-form.tsx`.
+- [ ] Use the helper in `addFiles` before calling `readFileAsDataUrl`.
+- [ ] Change the file input `accept` attribute to the explicit accepted MIME list.
+- [ ] Run `npm test -- listing-create-form.test.tsx` and confirm it passes.
+
+### Task 3: Full Verification
+
+**Files:**
+- Verify current branch only.
+
+- [ ] Run `npm test`.
+- [ ] Run `npm run lint`.
+- [ ] Run `npm run build`.
+- [ ] Commit the implementation with `git commit -m "Harden local image uploads"`.
+

--- a/docs/superpowers/specs/2026-05-28-auth-polish-design.md
+++ b/docs/superpowers/specs/2026-05-28-auth-polish-design.md
@@ -1,0 +1,55 @@
+# Auth Polish Design
+
+## Goal
+
+Polish the existing local credentials auth experience without adding new auth products such as OAuth, password reset, email verification, or account deletion.
+
+## Scope
+
+In scope:
+
+- Redirect signed-in users away from `/login` and `/register` to the resolved callback URL.
+- Preserve the existing safe callback URL behavior so external URLs still fall back to `/listings`.
+- Make login and registration submission failures deterministic:
+  - invalid credentials show `Email or password is incorrect.`
+  - registration API errors show the API message when available
+  - network or unexpected sign-in failures show a friendly retry message
+- Disable auth form fields while submitting so users cannot edit duplicate in-flight submissions.
+- Keep credentials auth, JWT sessions, and current route protections unchanged.
+
+Out of scope:
+
+- OAuth providers.
+- Password reset.
+- Email verification.
+- Remember-me controls.
+- Account deletion or profile security settings.
+
+## User Experience
+
+Signed-out users can still access `/login` and `/register`. If a signed-in user visits either page, the page redirects them to the sanitized callback URL. For example, `/login?callbackUrl=/profile` redirects to `/profile`, while an external callback still redirects to `/listings`.
+
+Login and register forms keep their current layout. During submission, all inputs and the submit button are disabled. On recoverable failures, the form clears the progress notice, shows the relevant error, and returns to an editable state.
+
+## Implementation Shape
+
+Add server-side auth checks to the login and register pages using the existing `auth()` helper and `redirect()` from Next navigation.
+
+Extract small client helpers in the login and register form modules for submission result normalization. The React components should use those helpers so tests can cover failure handling without needing a browser DOM test harness.
+
+## Testing
+
+Add focused tests for:
+
+- `/login` redirects signed-in users to the safe callback URL.
+- `/register` redirects signed-in users to the safe callback URL.
+- login helper maps invalid credentials and thrown sign-in failures to friendly messages.
+- register helper maps API failures, sign-in failures, and thrown network failures to friendly messages.
+- form markup disables auth inputs while submitting where practical through component structure tests or helper coverage.
+
+Run:
+
+- `npm test`
+- `npm run lint`
+- `npm run build`
+

--- a/docs/superpowers/specs/2026-05-28-image-upload-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-28-image-upload-hardening-design.md
@@ -1,0 +1,66 @@
+# Image Upload Hardening Design
+
+## Goal
+
+Harden the current local image upload flow for listing create and edit forms without adding external storage, upload credentials, or deployment-specific services.
+
+## Scope
+
+This version keeps listing images as data URLs stored in `Listing.imageUrls`. It improves validation and user feedback around that existing approach.
+
+In scope:
+
+- Allow only JPEG, PNG, and WebP listing images.
+- Keep the existing maximum of five images per listing.
+- Add a per-image file size limit before files are read into memory.
+- Enforce image URL count, MIME, and data URL shape in API schemas.
+- Show clear form errors when a user selects unsupported files, oversized files, or too many files.
+- Preserve existing create/edit listing behavior and image previews.
+
+Out of scope:
+
+- Vercel Blob, Cloudinary, S3, or any other hosted image storage.
+- Server-side image resizing, compression, transcoding, or virus scanning.
+- Multi-part upload endpoints.
+- Image reorder controls.
+
+## Recommended Limits
+
+- Maximum images per listing: `5`.
+- Maximum size per selected file: `2 MB`.
+- Accepted MIME types: `image/jpeg`, `image/png`, `image/webp`.
+- Accepted stored values: HTTPS URLs or data URLs whose media type is one of the accepted MIME types.
+
+The schema should keep HTTPS URL support because existing seed/test data and future storage migration may use normal hosted URLs. It should not accept arbitrary data URL media types.
+
+## User Experience
+
+The listing form keeps the current drag/drop and "Choose images" controls. When files are selected:
+
+- Unsupported files are skipped and the form shows `Only JPEG, PNG, and WebP images are supported.`
+- Oversized files are skipped and the form shows `Each image must be 2 MB or smaller.`
+- If the user selects more images than remaining slots, the form adds only the allowed number and shows the remaining-slot message.
+- If no valid files remain after filtering, no previews are added.
+
+The file picker should advertise the allowed MIME types with an explicit `accept` value instead of generic `image/*`.
+
+## Validation
+
+Client validation prevents bad files before they are read by `FileReader`. API schema validation is the source of truth for saved listing payloads and rejects invalid or excessive `imageUrls` even if the UI is bypassed.
+
+The payload builder can continue to read hidden `imageUrls` fields from `FormData`; the hardening belongs in the image selection helper and the listing schemas.
+
+## Testing
+
+Add focused tests for:
+
+- Listing write schema accepts HTTPS URLs and valid JPEG/PNG/WebP data URLs.
+- Listing write schema rejects unsupported data URL MIME types.
+- Listing write schema rejects more than five image URLs.
+- The listing form image helper returns only accepted, in-limit files and explains rejected files.
+
+Run the existing local checks after implementation:
+
+- `npm test`
+- `npm run lint`
+- `npm run build`


### PR DESCRIPTION
## Summary
- Harden local listing image uploads with shared limits for count, size, and accepted MIME types
- Enforce image URL validation in listing schemas while preserving HTTPS image URL support
- Improve login/register auth polish with signed-in redirects, safer submission error handling, and disabled fields during submit
- Add design specs, implementation plans, and focused tests for both slices

## Validation
- `npm test`
- `npm run lint`
- `npm run build`

## Notes
- This intentionally keeps image uploads local/base64 for now; no Vercel Blob, Cloudinary, or external storage credentials were added.
- Auth polish stays within the current credentials flow; no OAuth, password reset, or email verification was added.