### PR TITLE
Polish listing reviews

### DIFF
--- a/apps/web/src/app/api/listings/[id]/reviews/route.test.ts
+++ b/apps/web/src/app/api/listings/[id]/reviews/route.test.ts
@@ -5,7 +5,7 @@ import {
   createReview,
   getReviewsForListing,
 } from "@/features/reviews/mutations";
-import { authRequired } from "@/server/api/errors";
+import { authRequired, forbidden } from "@/server/api/errors";
 import { requireCurrentUser } from "@/server/auth/current-user";
 
 vi.mock("@/features/reviews/mutations", () => ({
@@ -138,5 +138,30 @@ describe("listing review APIs", () => {
       },
     });
     expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("returns FORBIDDEN when an owner reviews their own listing", async () => {
+    vi.mocked(createReview).mockRejectedValue(
+      forbidden("Listing owners cannot review their own listings."),
+    );
+
+    const response = await POST(
+      new Request(`http://localhost:3000/api/listings/${review.listingId}/reviews`, {
+        method: "POST",
+        body: JSON.stringify({
+          body: review.body,
+          rating: review.rating,
+        }),
+      }),
+      { params: Promise.resolve({ id: review.listingId }) },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "FORBIDDEN",
+        message: "Listing owners cannot review their own listings.",
+      },
+    });
   });
 });

--- a/apps/web/src/app/listings/[id]/page.test.tsx
+++ b/apps/web/src/app/listings/[id]/page.test.tsx
@@ -145,6 +145,40 @@ function hasContactRequestForm(
   );
 }
 
+function reviewSectionIsOwner(
+  node: unknown,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (Array.isArray(node)) {
+    return node.some((child) => reviewSectionIsOwner(child, seen));
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  if (seen.has(node)) {
+    return false;
+  }
+  seen.add(node);
+
+  const element = node as {
+    props?: {
+      listingId?: unknown;
+      isOwner?: unknown;
+      children?: unknown;
+    };
+  };
+
+  if (element.props?.listingId === listing.id) {
+    return element.props.isOwner === true;
+  }
+
+  return Object.values(element.props ?? {}).some((value) =>
+    reviewSectionIsOwner(value, seen),
+  );
+}
+
 describe("ListingDetailPage", () => {
   beforeEach(() => {
     vi.mocked(getSavedListingIdsByUser).mockReset();
@@ -168,6 +202,7 @@ describe("ListingDetailPage", () => {
     });
 
     expect(hasHref(page, `/listings/${listing.id}/edit`)).toBe(true);
+    expect(reviewSectionIsOwner(page)).toBe(true);
   });
 
   it("loads and renders reviews for the listing", async () => {

--- a/apps/web/src/app/listings/[id]/page.tsx
+++ b/apps/web/src/app/listings/[id]/page.tsx
@@ -199,6 +199,7 @@ export default async function ListingDetailPage({
         listingId={listing.id}
         initialReviews={reviews.map(serializeReview)}
         currentUserId={session?.user?.id ?? null}
+        isOwner={isOwner}
       />
     </main>
   );

--- a/apps/web/src/features/reviews/components/review-section.test.tsx
+++ b/apps/web/src/features/reviews/components/review-section.test.tsx
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  averageReviewRating,
+  ReviewSectionView,
+  reviewRatingLabel,
+} from "@/features/reviews/components/review-section";
+import type { ReviewApiResponse } from "@/features/reviews/schemas";
+
+function includesText(
+  node: unknown,
+  text: string,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node).includes(text);
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  if (seen.has(node)) {
+    return false;
+  }
+  seen.add(node);
+
+  return Object.values(node).some((value) => includesText(value, text, seen));
+}
+
+const reviews: ReviewApiResponse[] = [
+  {
+    id: "review-1",
+    listingId: "listing-1",
+    authorId: "renter-1",
+    authorName: "Renter One",
+    body: "Accurate listing and helpful poster.",
+    rating: 5,
+    createdAt: "2026-05-19T12:00:00.000Z",
+    updatedAt: "2026-05-19T12:00:00.000Z",
+  },
+  {
+    id: "review-2",
+    listingId: "listing-1",
+    authorId: "renter-2",
+    authorName: "Renter Two",
+    body: "Good location.",
+    rating: 4,
+    createdAt: "2026-05-20T12:00:00.000Z",
+    updatedAt: "2026-05-20T12:00:00.000Z",
+  },
+  {
+    id: "review-3",
+    listingId: "listing-1",
+    authorId: "renter-3",
+    authorName: "Renter Three",
+    body: "No rating, just a note.",
+    rating: null,
+    createdAt: "2026-05-21T12:00:00.000Z",
+    updatedAt: "2026-05-21T12:00:00.000Z",
+  },
+];
+
+describe("review rating helpers", () => {
+  it("calculates an average from rated reviews only", () => {
+    expect(averageReviewRating(reviews)).toBe("4.5");
+  });
+
+  it("formats review ratings with a readable label", () => {
+    expect(reviewRatingLabel(4)).toBe("Rating: 4 out of 5");
+  });
+});
+
+describe("ReviewSection", () => {
+  it("shows average rating and clearer rating labels", () => {
+    const section = ReviewSectionView({
+      currentUserId: null,
+      editingReviewId: null,
+      initialReviews: reviews,
+      isSubmitting: false,
+      listingId: "listing-1",
+      onCreateReview: () => undefined,
+      onDeleteReview: () => undefined,
+      onEditReview: () => undefined,
+      onUpdateReview: () => undefined,
+      error: null,
+      notice: null,
+      setEditingReviewId: () => undefined,
+    });
+
+    expect(includesText(section, "4.5 average from 2 ratings")).toBe(true);
+    expect(includesText(section, "Rating: 5 out of 5")).toBe(true);
+  });
+
+  it("shows owner copy instead of the add-review form for listing owners", () => {
+    const section = ReviewSectionView({
+      currentUserId: "owner-1",
+      editingReviewId: null,
+      initialReviews: reviews,
+      isOwner: true,
+      isSubmitting: false,
+      listingId: "listing-1",
+      onCreateReview: () => undefined,
+      onDeleteReview: () => undefined,
+      onEditReview: () => undefined,
+      onUpdateReview: () => undefined,
+      error: null,
+      notice: null,
+      setEditingReviewId: () => undefined,
+    });
+
+    expect(includesText(section, "Owners cannot review their own listings.")).toBe(
+      true,
+    );
+    expect(includesText(section, "Post review")).toBe(false);
+  });
+});

--- a/apps/web/src/features/reviews/components/review-section.tsx
+++ b/apps/web/src/features/reviews/components/review-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState, type FormEvent } from "react";
+import { useState, type Dispatch, type FormEvent, type SetStateAction } from "react";
 
 import type { ReviewApiResponse } from "@/features/reviews/schemas";
 import { FormFeedback } from "@/features/ui/form-feedback";
@@ -10,6 +10,7 @@ type ReviewSectionProps = {
   listingId: string;
   initialReviews: ReviewApiResponse[];
   currentUserId?: string | null;
+  isOwner?: boolean;
 };
 
 type ApiErrorBody = {
@@ -27,10 +28,252 @@ function reviewAuthor(review: ReviewApiResponse) {
   return review.authorName ?? "AllApartments user";
 }
 
+export function averageReviewRating(reviews: ReviewApiResponse[]) {
+  const ratedReviews = reviews.filter(
+    (review): review is ReviewApiResponse & { rating: number } =>
+      review.rating !== null,
+  );
+
+  if (ratedReviews.length === 0) {
+    return null;
+  }
+
+  const average =
+    ratedReviews.reduce((total, review) => total + review.rating, 0) /
+    ratedReviews.length;
+
+  return Number.isInteger(average) ? String(average) : average.toFixed(1);
+}
+
+function ratedReviewCount(reviews: ReviewApiResponse[]) {
+  return reviews.filter((review) => review.rating !== null).length;
+}
+
+export function reviewRatingLabel(rating: number) {
+  return `Rating: ${rating} out of 5`;
+}
+
+type ReviewSectionViewProps = ReviewSectionProps & {
+  editingReviewId: string | null;
+  error: string | null;
+  initialReviews: ReviewApiResponse[];
+  isSubmitting: boolean;
+  notice: string | null;
+  onCreateReview: (event: FormEvent<HTMLFormElement>) => void;
+  onDeleteReview: (reviewId: string) => void;
+  onEditReview: (reviewId: string) => void;
+  onUpdateReview: (
+    event: FormEvent<HTMLFormElement>,
+    reviewId: string,
+  ) => void;
+  setEditingReviewId: Dispatch<SetStateAction<string | null>>;
+};
+
+export function ReviewSectionView({
+  currentUserId,
+  editingReviewId,
+  error,
+  initialReviews: reviews,
+  isOwner = false,
+  isSubmitting,
+  notice,
+  onCreateReview,
+  onDeleteReview,
+  onEditReview,
+  onUpdateReview,
+  setEditingReviewId,
+}: ReviewSectionViewProps) {
+  const isSignedIn = Boolean(currentUserId);
+  const averageRating = averageReviewRating(reviews);
+  const ratingCount = ratedReviewCount(reviews);
+
+  return (
+    <section className="mt-10 border-t border-zinc-200 pt-8">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-semibold text-zinc-950">
+            Reviews and comments
+          </h2>
+          <p className="mt-1 text-sm text-zinc-600">
+            {reviews.length === 0
+              ? "No reviews yet."
+              : `${reviews.length} review${reviews.length === 1 ? "" : "s"}`}
+          </p>
+          {averageRating ? (
+            <p className="mt-1 text-sm font-medium text-emerald-700">
+              {`${averageRating} average from ${ratingCount} rating${
+                ratingCount === 1 ? "" : "s"
+              }`}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {error ? (
+        <div className="mt-4">
+          <FormFeedback tone="error">{error}</FormFeedback>
+        </div>
+      ) : null}
+      {notice ? (
+        <div className="mt-4">
+          <FormFeedback tone={isSubmitting ? "info" : "success"}>
+            {notice}
+          </FormFeedback>
+        </div>
+      ) : null}
+
+      {isOwner ? (
+        <p className="mt-5 rounded-md border border-zinc-200 px-4 py-3 text-sm text-zinc-700">
+          Owners cannot review their own listings.
+        </p>
+      ) : isSignedIn ? (
+        <form onSubmit={onCreateReview} className="mt-5 grid gap-3">
+          <label htmlFor="review-body" className="text-sm font-medium text-zinc-800">
+            Add a comment
+          </label>
+          <textarea
+            id="review-body"
+            name="body"
+            required
+            rows={4}
+            disabled={isSubmitting}
+            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950 disabled:bg-zinc-100"
+            placeholder="Share what future renters should know."
+          />
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="grid gap-2">
+              <label htmlFor="review-rating" className="text-sm font-medium text-zinc-800">
+                Rating
+              </label>
+              <select
+                id="review-rating"
+                name="rating"
+                defaultValue=""
+                disabled={isSubmitting}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950 disabled:bg-zinc-100"
+              >
+                <option value="">No rating</option>
+                <option value="5">5</option>
+                <option value="4">4</option>
+                <option value="3">3</option>
+                <option value="2">2</option>
+                <option value="1">1</option>
+              </select>
+            </div>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+            >
+              {isSubmitting ? "Posting..." : "Post review"}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <p className="mt-5 rounded-md border border-zinc-200 px-4 py-3 text-sm text-zinc-700">
+          Sign in to add a comment or rating.
+        </p>
+      )}
+
+      <div className="mt-6 grid gap-5">
+        {reviews.map((review) => {
+          const isAuthor = currentUserId === review.authorId;
+          const isEditing = editingReviewId === review.id;
+
+          return (
+            <article key={review.id} className="border-t border-zinc-200 pt-5">
+              {isEditing ? (
+                <form
+                  onSubmit={(event) => onUpdateReview(event, review.id)}
+                  className="grid gap-3"
+                >
+                  <textarea
+                    name="body"
+                    required
+                    rows={4}
+                    defaultValue={review.body}
+                    disabled={isSubmitting}
+                    className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950 disabled:bg-zinc-100"
+                  />
+                  <div className="flex flex-wrap items-center gap-3">
+                    <select
+                      name="rating"
+                      defaultValue={review.rating ?? ""}
+                      disabled={isSubmitting}
+                      className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950 disabled:bg-zinc-100"
+                    >
+                      <option value="">No rating</option>
+                      <option value="5">5</option>
+                      <option value="4">4</option>
+                      <option value="3">3</option>
+                      <option value="2">2</option>
+                      <option value="1">1</option>
+                    </select>
+                    <button
+                      type="submit"
+                      disabled={isSubmitting}
+                      className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+                    >
+                      Save
+                    </button>
+                    <button
+                      type="button"
+                      disabled={isSubmitting}
+                      onClick={() => setEditingReviewId(null)}
+                      className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-800 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:bg-zinc-100 disabled:text-zinc-400"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              ) : (
+                <div className="grid gap-2">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <p className="text-sm font-medium text-zinc-950">
+                      {reviewAuthor(review)}
+                    </p>
+                    {review.rating ? (
+                      <p className="text-sm font-semibold text-emerald-700">
+                        {reviewRatingLabel(review.rating)}
+                      </p>
+                    ) : null}
+                  </div>
+                  <p className="leading-7 text-zinc-700">{review.body}</p>
+                  {isAuthor ? (
+                    <div className="flex flex-wrap gap-3">
+                      <button
+                        type="button"
+                        onClick={() => onEditReview(review.id)}
+                        disabled={isSubmitting}
+                        className="text-sm font-medium text-zinc-950 underline-offset-4 hover:underline disabled:text-zinc-400"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onDeleteReview(review.id)}
+                        disabled={isSubmitting}
+                        className="text-sm font-medium text-red-700 underline-offset-4 hover:underline disabled:text-red-300"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 export function ReviewSection({
   listingId,
   initialReviews,
   currentUserId,
+  isOwner = false,
 }: ReviewSectionProps) {
   const router = useRouter();
   const [reviews, setReviews] = useState(initialReviews);
@@ -38,7 +281,6 @@ export function ReviewSection({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const isSignedIn = Boolean(currentUserId);
 
   async function createReview(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -169,166 +411,20 @@ export function ReviewSection({
   }
 
   return (
-    <section className="mt-10 border-t border-zinc-200 pt-8">
-      <div className="flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <h2 className="text-2xl font-semibold text-zinc-950">
-            Reviews and comments
-          </h2>
-          <p className="mt-1 text-sm text-zinc-600">
-            {reviews.length === 0
-              ? "No reviews yet."
-              : `${reviews.length} review${reviews.length === 1 ? "" : "s"}`}
-          </p>
-        </div>
-      </div>
-
-      {error ? (
-        <div className="mt-4">
-          <FormFeedback tone="error">{error}</FormFeedback>
-        </div>
-      ) : null}
-      {notice ? (
-        <div className="mt-4">
-          <FormFeedback tone={isSubmitting ? "info" : "success"}>
-            {notice}
-          </FormFeedback>
-        </div>
-      ) : null}
-
-      {isSignedIn ? (
-        <form onSubmit={createReview} className="mt-5 grid gap-3">
-          <label htmlFor="review-body" className="text-sm font-medium text-zinc-800">
-            Add a comment
-          </label>
-          <textarea
-            id="review-body"
-            name="body"
-            required
-            rows={4}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
-            placeholder="Share what future renters should know."
-          />
-          <div className="flex flex-wrap items-end gap-3">
-            <div className="grid gap-2">
-              <label htmlFor="review-rating" className="text-sm font-medium text-zinc-800">
-                Rating
-              </label>
-              <select
-                id="review-rating"
-                name="rating"
-                defaultValue=""
-                className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
-              >
-                <option value="">No rating</option>
-                <option value="5">5</option>
-                <option value="4">4</option>
-                <option value="3">3</option>
-                <option value="2">2</option>
-                <option value="1">1</option>
-              </select>
-            </div>
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
-            >
-              {isSubmitting ? "Posting..." : "Post review"}
-            </button>
-          </div>
-        </form>
-      ) : (
-        <p className="mt-5 rounded-md border border-zinc-200 px-4 py-3 text-sm text-zinc-700">
-          Sign in to add a comment or rating.
-        </p>
-      )}
-
-      <div className="mt-6 grid gap-5">
-        {reviews.map((review) => {
-          const isAuthor = currentUserId === review.authorId;
-          const isEditing = editingReviewId === review.id;
-
-          return (
-            <article key={review.id} className="border-t border-zinc-200 pt-5">
-              {isEditing ? (
-                <form
-                  onSubmit={(event) => updateReview(event, review.id)}
-                  className="grid gap-3"
-                >
-                  <textarea
-                    name="body"
-                    required
-                    rows={4}
-                    defaultValue={review.body}
-                    className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
-                  />
-                  <div className="flex flex-wrap items-center gap-3">
-                    <select
-                      name="rating"
-                      defaultValue={review.rating ?? ""}
-                      className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
-                    >
-                      <option value="">No rating</option>
-                      <option value="5">5</option>
-                      <option value="4">4</option>
-                      <option value="3">3</option>
-                      <option value="2">2</option>
-                      <option value="1">1</option>
-                    </select>
-                    <button
-                      type="submit"
-                      disabled={isSubmitting}
-                      className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
-                    >
-                      Save
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setEditingReviewId(null)}
-                      className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-800 hover:bg-zinc-50"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </form>
-              ) : (
-                <div className="grid gap-2">
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <p className="text-sm font-medium text-zinc-950">
-                      {reviewAuthor(review)}
-                    </p>
-                    {review.rating ? (
-                      <p className="text-sm font-semibold text-emerald-700">
-                        {review.rating}/5
-                      </p>
-                    ) : null}
-                  </div>
-                  <p className="leading-7 text-zinc-700">{review.body}</p>
-                  {isAuthor ? (
-                    <div className="flex flex-wrap gap-3">
-                      <button
-                        type="button"
-                        onClick={() => setEditingReviewId(review.id)}
-                        className="text-sm font-medium text-zinc-950 underline-offset-4 hover:underline"
-                      >
-                        Edit
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => void deleteReview(review.id)}
-                        disabled={isSubmitting}
-                        className="text-sm font-medium text-red-700 underline-offset-4 hover:underline disabled:text-red-300"
-                      >
-                        Delete
-                      </button>
-                    </div>
-                  ) : null}
-                </div>
-              )}
-            </article>
-          );
-        })}
-      </div>
-    </section>
+    <ReviewSectionView
+      currentUserId={currentUserId}
+      editingReviewId={editingReviewId}
+      error={error}
+      initialReviews={reviews}
+      isOwner={isOwner}
+      isSubmitting={isSubmitting}
+      listingId={listingId}
+      notice={notice}
+      onCreateReview={createReview}
+      onDeleteReview={(reviewId) => void deleteReview(reviewId)}
+      onEditReview={setEditingReviewId}
+      onUpdateReview={updateReview}
+      setEditingReviewId={setEditingReviewId}
+    />
   );
 }

--- a/apps/web/src/features/reviews/mutations.test.ts
+++ b/apps/web/src/features/reviews/mutations.test.ts
@@ -10,6 +10,9 @@ import { prisma } from "@/server/db/prisma";
 
 vi.mock("@/server/db/prisma", () => ({
   prisma: {
+    listing: {
+      findUnique: vi.fn(),
+    },
     review: {
       create: vi.fn(),
       delete: vi.fn(),
@@ -31,6 +34,7 @@ describe("review mutations", () => {
     vi.mocked(prisma.review.findMany).mockReset();
     vi.mocked(prisma.review.findUnique).mockReset();
     vi.mocked(prisma.review.update).mockReset();
+    vi.mocked(prisma.listing.findUnique).mockReset();
     process.env.DATABASE_URL = "mongodb://example.test/allapartments";
   });
 
@@ -58,6 +62,10 @@ describe("review mutations", () => {
   });
 
   it("creates a review connected to the listing and signed-in author", async () => {
+    vi.mocked(prisma.listing.findUnique).mockResolvedValue({
+      id: listingId,
+      ownerId: "507f1f77bcf86cd799439088",
+    });
     vi.mocked(prisma.review.create).mockResolvedValue({});
 
     await createReview(
@@ -93,6 +101,27 @@ describe("review mutations", () => {
         },
       },
     });
+  });
+
+  it("blocks listing owners from reviewing their own listings", async () => {
+    vi.mocked(prisma.listing.findUnique).mockResolvedValue({
+      id: listingId,
+      ownerId: authorId,
+    });
+
+    await expect(
+      createReview(
+        listingId,
+        {
+          body: "Reviewing my own listing.",
+          rating: 5,
+        },
+        authorId,
+      ),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(prisma.review.create).not.toHaveBeenCalled();
   });
 
   it("blocks updates from users who did not author the review", async () => {

--- a/apps/web/src/features/reviews/mutations.ts
+++ b/apps/web/src/features/reviews/mutations.ts
@@ -44,6 +44,20 @@ export async function createReview(
     return null;
   }
 
+  const listing = await prisma.listing.findUnique({
+    where: {
+      id: listingId,
+    },
+    select: {
+      id: true,
+      ownerId: true,
+    },
+  });
+
+  if (listing?.ownerId === authorId) {
+    throw forbidden("Listing owners cannot review their own listings.");
+  }
+
   return prisma.review.create({
     data: {
       body: input.body,

--- a/docs/superpowers/plans/2026-05-29-reviews-polish.md
+++ b/docs/superpowers/plans/2026-05-29-reviews-polish.md
@@ -30,15 +30,15 @@
 - Modify: `apps/web/src/app/listings/[id]/page.tsx`
 - Test: `apps/web/src/app/listings/[id]/page.test.tsx`
 
-- [ ] Write failing tests for average rating text, individual rating label text, and owner copy hiding the add-review form.
-- [ ] Run `npm test -- review-section.test.tsx listings/[id]/page.test.tsx` and confirm the new tests fail.
-- [ ] Export `averageReviewRating(reviews)` and `reviewRatingLabel(rating)` from `review-section.tsx`.
-- [ ] Add `isOwner?: boolean` to `ReviewSectionProps`.
-- [ ] Show average rating text when at least one review has a rating.
-- [ ] Render individual ratings through `reviewRatingLabel`.
-- [ ] Show owner copy instead of the create form when `isOwner` is true.
-- [ ] Pass `isOwner={isOwner}` from the listing detail page.
-- [ ] Run `npm test -- review-section.test.tsx listings/[id]/page.test.tsx` and confirm it passes.
+- [x] Write failing tests for average rating text, individual rating label text, and owner copy hiding the add-review form.
+- [x] Run `npm test -- review-section.test.tsx listings/[id]/page.test.tsx` and confirm the new tests fail.
+- [x] Export `averageReviewRating(reviews)` and `reviewRatingLabel(rating)` from `review-section.tsx`.
+- [x] Add `isOwner?: boolean` to `ReviewSectionProps`.
+- [x] Show average rating text when at least one review has a rating.
+- [x] Render individual ratings through `reviewRatingLabel`.
+- [x] Show owner copy instead of the create form when `isOwner` is true.
+- [x] Pass `isOwner={isOwner}` from the listing detail page.
+- [x] Run `npm test -- review-section.test.tsx listings/[id]/page.test.tsx` and confirm it passes.
 
 ### Task 2: Owner Self-Review Blocking
 
@@ -47,21 +47,20 @@
 - Test: `apps/web/src/features/reviews/mutations.test.ts`
 - Test: `apps/web/src/app/api/listings/[id]/reviews/route.test.ts`
 
-- [ ] Write failing mutation test that `createReview` throws `FORBIDDEN` when the listing owner id matches the author id.
-- [ ] Write failing route test that owner self-review returns `403`.
-- [ ] Run `npm test -- reviews` and confirm owner-blocking tests fail.
-- [ ] In `createReview`, read the listing owner before creating the review.
-- [ ] Throw `forbidden("Listing owners cannot review their own listings.")` when owner and author match.
-- [ ] Keep no-database behavior returning `null`.
-- [ ] Run `npm test -- reviews` and confirm it passes.
+- [x] Write failing mutation test that `createReview` throws `FORBIDDEN` when the listing owner id matches the author id.
+- [x] Write failing route test that owner self-review returns `403`.
+- [x] Run `npm test -- reviews` and confirm owner-blocking tests fail.
+- [x] In `createReview`, read the listing owner before creating the review.
+- [x] Throw `forbidden("Listing owners cannot review their own listings.")` when owner and author match.
+- [x] Keep no-database behavior returning `null`.
+- [x] Run `npm test -- reviews` and confirm it passes.
 
 ### Task 3: Full Verification
 
 **Files:**
 - Verify current branch only.
 
-- [ ] Run `npm test`.
-- [ ] Run `npm run lint`.
-- [ ] Run `npm run build`.
-- [ ] Commit with `git commit -m "Polish listing reviews"`.
-
+- [x] Run `npm test`.
+- [x] Run `npm run lint`.
+- [x] Run `npm run build`.
+- [x] Commit with `git commit -m "Polish listing reviews"`.

--- a/docs/superpowers/plans/2026-05-29-reviews-polish.md
+++ b/docs/superpowers/plans/2026-05-29-reviews-polish.md
@@ -1,0 +1,67 @@
+# Reviews Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make listing reviews clearer and block listing owners from reviewing their own listings.
+
+**Architecture:** Keep the existing `Review` model and review API routes. Add small pure UI helpers for rating summary/labels, pass ownership state from the listing detail page into the review section, and enforce owner self-review blocking in the mutation layer.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, Prisma, Zod, Vitest.
+
+---
+
+## File Structure
+
+- Modify `apps/web/src/features/reviews/components/review-section.tsx`: add average rating helpers, clearer rating labels, owner-aware UI, and disabled edit controls while submitting.
+- Create or modify `apps/web/src/features/reviews/components/review-section.test.tsx`: test average rating, rating label, owner UI state, and review section copy.
+- Modify `apps/web/src/app/listings/[id]/page.tsx`: pass `isOwner` into `ReviewSection`.
+- Modify `apps/web/src/app/listings/[id]/page.test.tsx`: assert owners pass owner state and non-owners do not.
+- Modify `apps/web/src/features/reviews/mutations.ts`: make `createReview` check listing ownership before create.
+- Modify `apps/web/src/features/reviews/mutations.test.ts`: test owner self-review blocking and non-owner create behavior.
+- Modify `apps/web/src/app/api/listings/[id]/reviews/route.test.ts`: test owner blocking is surfaced as `403`.
+
+## Tasks
+
+### Task 1: Review UI Summary and Owner State
+
+**Files:**
+- Modify: `apps/web/src/features/reviews/components/review-section.tsx`
+- Test: `apps/web/src/features/reviews/components/review-section.test.tsx`
+- Modify: `apps/web/src/app/listings/[id]/page.tsx`
+- Test: `apps/web/src/app/listings/[id]/page.test.tsx`
+
+- [ ] Write failing tests for average rating text, individual rating label text, and owner copy hiding the add-review form.
+- [ ] Run `npm test -- review-section.test.tsx listings/[id]/page.test.tsx` and confirm the new tests fail.
+- [ ] Export `averageReviewRating(reviews)` and `reviewRatingLabel(rating)` from `review-section.tsx`.
+- [ ] Add `isOwner?: boolean` to `ReviewSectionProps`.
+- [ ] Show average rating text when at least one review has a rating.
+- [ ] Render individual ratings through `reviewRatingLabel`.
+- [ ] Show owner copy instead of the create form when `isOwner` is true.
+- [ ] Pass `isOwner={isOwner}` from the listing detail page.
+- [ ] Run `npm test -- review-section.test.tsx listings/[id]/page.test.tsx` and confirm it passes.
+
+### Task 2: Owner Self-Review Blocking
+
+**Files:**
+- Modify: `apps/web/src/features/reviews/mutations.ts`
+- Test: `apps/web/src/features/reviews/mutations.test.ts`
+- Test: `apps/web/src/app/api/listings/[id]/reviews/route.test.ts`
+
+- [ ] Write failing mutation test that `createReview` throws `FORBIDDEN` when the listing owner id matches the author id.
+- [ ] Write failing route test that owner self-review returns `403`.
+- [ ] Run `npm test -- reviews` and confirm owner-blocking tests fail.
+- [ ] In `createReview`, read the listing owner before creating the review.
+- [ ] Throw `forbidden("Listing owners cannot review their own listings.")` when owner and author match.
+- [ ] Keep no-database behavior returning `null`.
+- [ ] Run `npm test -- reviews` and confirm it passes.
+
+### Task 3: Full Verification
+
+**Files:**
+- Verify current branch only.
+
+- [ ] Run `npm test`.
+- [ ] Run `npm run lint`.
+- [ ] Run `npm run build`.
+- [ ] Commit with `git commit -m "Polish listing reviews"`.
+

--- a/docs/superpowers/specs/2026-05-29-reviews-polish-design.md
+++ b/docs/superpowers/specs/2026-05-29-reviews-polish-design.md
@@ -1,0 +1,59 @@
+# Reviews Polish Design
+
+## Goal
+
+Make listing reviews and ratings easier to understand and safer to use without changing the review data model or introducing building-level review concepts.
+
+## Scope
+
+This slice keeps reviews attached to individual listings. It improves the existing listing-detail review section and hardens review ownership rules.
+
+In scope:
+
+- Show an average rating summary when at least one review has a rating.
+- Render individual ratings with a clearer label instead of only `5/5`.
+- Prevent listing owners from reviewing their own listings in the UI and server-side mutation path.
+- Keep signed-out users prompted to sign in before reviewing.
+- Disable create/edit/delete controls consistently while review requests are in progress.
+- Add focused tests for rating summaries, rating labels, and owner review blocking.
+
+Out of scope:
+
+- Building or apartment-complex review models.
+- Moderation, flagging, or hidden review states.
+- Review helpfulness votes.
+- Review replies.
+- Changing existing review API paths.
+
+## User Experience
+
+On a listing detail page, renters see a reviews section with the review count and, when ratings exist, the average rating. Individual review cards display the author, optional rating, and body. Rating display should be text-safe and readable without relying on custom icons.
+
+Signed-out users continue to see a prompt to sign in. Listing owners can read reviews but do not see the add-review form for their own listings. If an owner bypasses the UI and calls the API, the mutation rejects the request.
+
+## Data Flow
+
+The listing detail page already knows whether the current user owns the listing. It should pass that ownership state into `ReviewSection`. The review create route should pass the listing id and author id into the mutation, and the mutation should verify the listing owner before creating.
+
+No Prisma schema change is required because `Review` already stores `listingId`, `authorId`, `body`, and optional `rating`.
+
+## Error Handling
+
+Owner self-review attempts should return `FORBIDDEN` with a clear message. UI failures should keep using the existing `FormFeedback` pattern and should not leave forms stuck in a submitting state.
+
+## Testing
+
+Add or update tests for:
+
+- average rating calculation and display;
+- individual rating label display;
+- signed-in owners do not see the add-review form;
+- `createReview` rejects listing owners;
+- the review POST route surfaces owner blocking through existing API error handling.
+
+Run:
+
+- `npm test`
+- `npm run lint`
+- `npm run build`
+


### PR DESCRIPTION
## Summary
- Add average rating summaries and clearer rating labels to listing reviews
- Pass listing-owner state into the review section so owners see a read-only owner message instead of an add-review form
- Block listing owners from reviewing their own listings in the review mutation path
- Add focused tests for review UI helpers, listing owner state, mutation blocking, and API forbidden responses

## Validation
- `npm test`
- `npm run lint`
- `npm run build`

## Notes
- This keeps reviews attached to individual listings. No building-level review model, moderation flow, replies, or API route changes were added.