### PR TITLE
Frontend redesign: warm-wood design system across all pages

### DIFF
--- a/apps/web/src/app/app-footer.tsx
+++ b/apps/web/src/app/app-footer.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+
+import { Container } from "@/features/ui/container";
+import { HomeMarkIcon } from "@/features/ui/icons";
+
+const LINKS = [
+  { href: "/listings", label: "Browse listings" },
+  { href: "/listings/new", label: "Post a place" },
+  { href: "/profile", label: "Your profile" },
+  { href: "/api-docs", label: "API docs" },
+];
+
+export function AppFooter() {
+  return (
+    <footer className="mt-20 border-t border-stone-200/70 bg-brand-50/40">
+      <Container>
+        <div className="flex flex-col gap-8 py-12 sm:flex-row sm:items-start sm:justify-between">
+          <div className="max-w-sm">
+            <div className="flex items-center gap-2.5">
+              <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-brand-800 text-brand-50">
+                <HomeMarkIcon width={18} height={18} />
+              </span>
+              <span className="font-display text-base font-semibold text-stone-950">
+                AllApartments
+              </span>
+            </div>
+            <p className="mt-3 text-sm leading-6 text-stone-600">
+              A warm, local-first board for apartments, rooms, and roommate
+              leads — built to make finding a home feel a little more human.
+            </p>
+          </div>
+
+          <nav className="grid grid-cols-2 gap-x-12 gap-y-2 text-sm">
+            {LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="text-stone-600 transition-colors hover:text-brand-800"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+        <div className="border-t border-stone-200/70 py-6 text-xs text-stone-500">
+          © {new Date().getFullYear()} AllApartments. Find apartments, rooms,
+          and roommates.
+        </div>
+      </Container>
+    </footer>
+  );
+}

--- a/apps/web/src/app/app-nav.tsx
+++ b/apps/web/src/app/app-nav.tsx
@@ -1,52 +1,66 @@
 import Link from "next/link";
 
+import { NavLink } from "@/app/nav-link";
+import { buttonVariants } from "@/features/ui/button";
+import { Container } from "@/features/ui/container";
+import { HomeMarkIcon } from "@/features/ui/icons";
 import { auth, signOut } from "@/server/auth/auth";
 
 export async function AppNav() {
   const session = await auth();
 
   return (
-    <header className="border-b border-zinc-200">
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-4">
-        <Link href="/" className="text-sm font-semibold text-zinc-950">
-          AllApartments
-        </Link>
-        <nav className="flex items-center gap-4 text-sm">
-          <Link href="/listings" className="text-zinc-700 hover:text-zinc-950">
-            Listings
+    <header className="sticky top-0 z-40 border-b border-stone-200/70 bg-background/85 backdrop-blur-md">
+      <Container>
+        <div className="flex h-16 items-center justify-between gap-4">
+          <Link
+            href="/"
+            className="group flex items-center gap-2.5"
+            aria-label="AllApartments home"
+          >
+            <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-800 text-brand-50 shadow-[var(--shadow-soft)] transition-transform group-hover:-rotate-3">
+              <HomeMarkIcon width={20} height={20} />
+            </span>
+            <span className="font-display text-lg font-semibold text-stone-950">
+              AllApartments
+            </span>
           </Link>
-          <Link href="/listings/new" className="text-zinc-700 hover:text-zinc-950">
-            Post
-          </Link>
-          {session?.user ? (
-            <>
-              <Link href="/profile" className="text-zinc-700 hover:text-zinc-950">
-                Profile
-              </Link>
-              <form
-                action={async () => {
-                  "use server";
-                  await signOut({ redirectTo: "/" });
-                }}
-              >
-                <button
-                  type="submit"
-                  className="rounded-md border border-zinc-300 px-3 py-1.5 text-zinc-950 hover:bg-zinc-100"
+
+          <nav className="flex items-center gap-1 sm:gap-2">
+            <NavLink href="/listings">Listings</NavLink>
+            <NavLink href="/listings/new">Post</NavLink>
+            {session?.user ? (
+              <>
+                <NavLink href="/profile">Profile</NavLink>
+                <form
+                  action={async () => {
+                    "use server";
+                    await signOut({ redirectTo: "/" });
+                  }}
                 >
-                  Sign out
-                </button>
-              </form>
-            </>
-          ) : (
-            <Link
-              href="/login"
-              className="rounded-md bg-zinc-950 px-3 py-1.5 text-white hover:bg-zinc-800"
-            >
-              Sign in
-            </Link>
-          )}
-        </nav>
-      </div>
+                  <button
+                    type="submit"
+                    className={buttonVariants({
+                      variant: "secondary",
+                      size: "sm",
+                      className: "ml-1",
+                    })}
+                  >
+                    Sign out
+                  </button>
+                </form>
+              </>
+            ) : (
+              <Link
+                href="/login"
+                className={buttonVariants({ size: "sm", className: "ml-1" })}
+              >
+                Sign in
+              </Link>
+            )}
+          </nav>
+        </div>
+      </Container>
     </header>
   );
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,20 +1,81 @@
 @import "tailwindcss";
 @import "swagger-ui-react/swagger-ui.css";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
+/*
+  AllApartments design system — "warm wood"
+  A cozy, editorial housing marketplace palette: cream paper, walnut/oak
+  brand tones, and warm stone neutrals. Serif display + humanist sans body.
+*/
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: Arial, Helvetica, sans-serif;
+@theme {
+  /* Warm paper + ink */
+  --color-background: #fbf7f1;
+  --color-surface: #ffffff;
+  --color-foreground: #2b2521;
+
+  /* Brand — oak / walnut / clay */
+  --color-brand-50: #fbf4ea;
+  --color-brand-100: #f4e4cd;
+  --color-brand-200: #e9c89c;
+  --color-brand-300: #dca969;
+  --color-brand-400: #cd8d44;
+  --color-brand-500: #bd7733;
+  --color-brand-600: #a35f29;
+  --color-brand-700: #834922;
+  --color-brand-800: #6a3b21;
+  --color-brand-900: #58321f;
+  --color-brand-950: #32190e;
+
+  /* Type */
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+  --font-serif: "Georgia", "Iowan Old Style", "Palatino Linotype", "Book Antiqua",
+    serif;
   --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+
+  /* Soft, warm shadows (brown-tinted rather than neutral gray) */
+  --shadow-soft: 0 1px 2px rgba(80, 50, 25, 0.04),
+    0 8px 24px -12px rgba(80, 50, 25, 0.18);
+  --shadow-lift: 0 2px 4px rgba(80, 50, 25, 0.05),
+    0 18px 40px -18px rgba(80, 50, 25, 0.28);
 }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+@layer base {
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    background-color: var(--color-background);
+    color: var(--color-foreground);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  ::selection {
+    background-color: var(--color-brand-200);
+    color: var(--color-brand-950);
+  }
+
+  /* Consistent, on-brand focus ring for keyboard users */
+  :focus-visible {
+    outline: 2px solid var(--color-brand-500);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+}
+
+@layer components {
+  .font-display {
+    font-family: var(--font-serif);
+    letter-spacing: -0.01em;
+  }
+
+  /* Subtle warm grain/wash used behind hero + section accents */
+  .surface-grain {
+    background-image:
+      radial-gradient(60rem 30rem at 110% -10%, rgba(189, 119, 51, 0.1), transparent 60%),
+      radial-gradient(50rem 28rem at -10% 0%, rgba(220, 169, 105, 0.12), transparent 55%);
+  }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,10 +1,15 @@
 import type { Metadata } from "next";
+import { AppFooter } from "@/app/app-footer";
 import { AppNav } from "@/app/app-nav";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "AllApartments",
-  description: "Find apartments, rooms, and roommate leads near campus.",
+  title: {
+    default: "AllApartments — apartments, rooms & roommates",
+    template: "%s · AllApartments",
+  },
+  description:
+    "Find apartments, rooms, and roommate leads near campus. A warm, local-first rental board.",
 };
 
 export default function RootLayout({
@@ -14,9 +19,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="h-full antialiased">
-      <body className="flex min-h-full flex-col">
+      <body className="flex min-h-full flex-col bg-background text-foreground">
         <AppNav />
-        {children}
+        <div className="flex-1">{children}</div>
+        <AppFooter />
       </body>
     </html>
   );

--- a/apps/web/src/app/listings/[id]/edit/page.tsx
+++ b/apps/web/src/app/listings/[id]/edit/page.tsx
@@ -1,5 +1,7 @@
 import { ListingCreateForm } from "@/features/listings/components/listing-create-form";
 import { getListingById } from "@/features/listings/queries";
+import { Eyebrow } from "@/features/ui/card";
+import { Container } from "@/features/ui/container";
 import { auth } from "@/server/auth/auth";
 import { notFound, redirect } from "next/navigation";
 
@@ -24,18 +26,18 @@ export default async function EditListingPage({ params }: EditListingPageProps) 
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-6 py-10">
-      <p className="text-sm font-semibold uppercase tracking-normal text-emerald-700">
-        Edit listing
-      </p>
-      <h1 className="mt-3 text-3xl font-semibold text-zinc-950">
-        Update your housing post.
-      </h1>
-      <p className="mt-4 leading-8 text-zinc-700">
-        Keep availability, price, and images current so students know what is
-        still open.
-      </p>
-      <ListingCreateForm mode="edit" listing={listing} />
+    <main className="py-10 sm:py-12">
+      <Container size="sm">
+        <Eyebrow>Edit listing</Eyebrow>
+        <h1 className="mt-3 font-display text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl">
+          Update your housing post.
+        </h1>
+        <p className="mt-4 leading-8 text-stone-600">
+          Keep availability, price, and images current so students know what is
+          still open.
+        </p>
+        <ListingCreateForm mode="edit" listing={listing} />
+      </Container>
     </main>
   );
 }

--- a/apps/web/src/app/listings/[id]/page.tsx
+++ b/apps/web/src/app/listings/[id]/page.tsx
@@ -8,6 +8,17 @@ import { getReviewsForListing } from "@/features/reviews/mutations";
 import { serializeReview } from "@/features/reviews/schemas";
 import { SavedListingButton } from "@/features/saved-listings/components/saved-listing-button";
 import { getSavedListingIdsByUser } from "@/features/saved-listings/queries";
+import { Badge, listingTypeLabel, listingStatusTone } from "@/features/ui/badge";
+import { buttonVariants } from "@/features/ui/button";
+import { Card } from "@/features/ui/card";
+import { Container } from "@/features/ui/container";
+import {
+  ArrowRightIcon,
+  CheckIcon,
+  MailIcon,
+  PhoneIcon,
+  PinIcon,
+} from "@/features/ui/icons";
 import { auth } from "@/server/auth/auth";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -77,130 +88,197 @@ export default async function ListingDetailPage({
   ];
 
   return (
-    <main className="mx-auto max-w-4xl px-6 py-10">
-      <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
-        <div className="text-sm font-medium uppercase text-emerald-700">
-          {listing.type}
+    <main className="py-8 sm:py-10">
+      <Container>
+        <Link
+          href="/listings"
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-stone-500 transition-colors hover:text-brand-800"
+        >
+          <ArrowRightIcon width={16} height={16} className="rotate-180" />
+          Back to listings
+        </Link>
+
+        <div className="mt-6 flex flex-wrap items-center gap-2">
+          <Badge tone="brand">{listingTypeLabel(listing.type)}</Badge>
+          {listing.status !== "ACTIVE" ? (
+            <Badge tone={listingStatusTone(listing.status)}>
+              {listing.status}
+            </Badge>
+          ) : null}
         </div>
-        {isOwner ? (
-          <div className="flex flex-wrap gap-3">
-            <Link
-              href={`/listings/${listing.id}/edit`}
-              className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
-            >
-              Edit
-            </Link>
-            <ListingArchiveButton listingId={listing.id} />
-          </div>
-        ) : session?.user?.id ? (
-          <SavedListingButton listingId={listing.id} initialSaved={isSaved} />
-        ) : (
-          <Link
-            href={`/login?callbackUrl=${encodeURIComponent(`/listings/${listing.id}`)}`}
-            className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-950 hover:bg-zinc-100"
-          >
-            Sign in to save
-          </Link>
-        )}
-      </div>
-      <h1 className="text-4xl font-semibold text-zinc-950">{listing.title}</h1>
-      <p className="mt-4 text-xl font-medium text-zinc-950">
-        ${listing.rent}/month
-      </p>
-      <p className="mt-6 leading-8 text-zinc-700">{listing.description}</p>
 
-      <ListingImageGallery imageUrls={listing.imageUrls} />
-
-      <dl className="mt-8 grid gap-4 sm:grid-cols-2">
-        {details.map(([label, value]) => (
-          <div key={label} className="border-t border-zinc-200 pt-4">
-            <dt className="text-sm text-zinc-500">{label}</dt>
-            <dd className="mt-1 font-medium text-zinc-950">{value}</dd>
-          </div>
-        ))}
-      </dl>
-
-      {listing.address ? (
-        <div className="mt-8 border-t border-zinc-200 pt-4">
-          <p className="text-sm text-zinc-500">Address</p>
-          <p className="mt-1 font-medium text-zinc-950">{listing.address}</p>
-        </div>
-      ) : null}
-
-      {roommateDetails.length > 0 ? (
-        <section className="mt-8 border-t border-zinc-200 pt-6">
-          <h2 className="text-lg font-semibold text-zinc-950">Roommate fit</h2>
-          <dl className="mt-4 grid gap-4 sm:grid-cols-2">
-            {roommateDetails.map(([label, value]) => (
-              <div key={label}>
-                <dt className="text-sm text-zinc-500">{label}</dt>
-                <dd className="mt-1 font-medium text-zinc-950">{value}</dd>
-              </div>
-            ))}
-          </dl>
-        </section>
-      ) : null}
-
-      {!isOwner && hasContactInfo ? (
-        <section className="mt-8 rounded-md border border-emerald-200 bg-emerald-50 px-5 py-4">
-          <p className="text-sm font-semibold text-emerald-900">
-            Contact poster
+        <h1 className="mt-3 max-w-3xl font-display text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl">
+          {listing.title}
+        </h1>
+        {listing.address ? (
+          <p className="mt-2 inline-flex items-center gap-1.5 text-sm text-stone-500">
+            <PinIcon width={16} height={16} className="text-brand-500" />
+            {listing.address}
           </p>
-          <div className="mt-3 flex flex-wrap gap-3">
-            {listing.contactEmail ? (
-              <a
-                href={`mailto:${listing.contactEmail}?subject=${encodeURIComponent(
-                  `Interested in ${listing.title}`,
-                )}`}
-                className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
-              >
-                Email poster
-              </a>
-            ) : null}
-            {listing.contactPhone ? (
-              <a
-                href={`tel:${listing.contactPhone}`}
-                className="rounded-md border border-emerald-300 px-4 py-2 text-sm font-medium text-emerald-950 hover:bg-emerald-100"
-              >
-                Call or text
-              </a>
-            ) : null}
-          </div>
-        </section>
-      ) : null}
+        ) : null}
 
-      {!isOwner && session?.user?.id ? (
-        <ContactRequestForm
-          listingId={listing.id}
-          defaultContactEmail={
-            profileUser?.contactEmail ?? session.user.email ?? null
-          }
-          defaultContactPhone={profileUser?.contactPhone ?? null}
-        />
-      ) : null}
+        <div className="mt-8 grid gap-8 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start">
+          {/* Main column */}
+          <div className="min-w-0">
+            <ListingImageGallery imageUrls={listing.imageUrls} />
 
-      {listing.amenities.length > 0 ? (
-        <div className="mt-8">
-          <p className="text-sm font-medium text-zinc-950">Amenities</p>
-          <div className="mt-3 flex flex-wrap gap-2">
-            {listing.amenities.map((amenity) => (
-              <span
-                key={amenity}
-                className="rounded-md border border-zinc-200 px-3 py-1 text-sm text-zinc-700"
-              >
-                {amenity}
-              </span>
-            ))}
+            <section className="mt-8">
+              <h2 className="text-lg font-semibold text-stone-950">
+                About this place
+              </h2>
+              <p className="mt-3 whitespace-pre-line leading-8 text-stone-700">
+                {listing.description}
+              </p>
+            </section>
+
+            <dl className="mt-8 grid gap-px overflow-hidden rounded-2xl border border-stone-200/80 bg-stone-200/60 sm:grid-cols-2">
+              {details.map(([label, value]) => (
+                <div key={label} className="bg-surface px-5 py-4">
+                  <dt className="text-xs font-medium uppercase tracking-wide text-stone-500">
+                    {label}
+                  </dt>
+                  <dd className="mt-1 font-medium text-stone-950">{value}</dd>
+                </div>
+              ))}
+            </dl>
+
+            {roommateDetails.length > 0 ? (
+              <section className="mt-8">
+                <h2 className="text-lg font-semibold text-stone-950">
+                  Roommate fit
+                </h2>
+                <dl className="mt-4 grid gap-4 sm:grid-cols-2">
+                  {roommateDetails.map(([label, value]) => (
+                    <div
+                      key={label}
+                      className="rounded-xl border border-stone-200/80 bg-surface px-4 py-3"
+                    >
+                      <dt className="text-xs font-medium uppercase tracking-wide text-stone-500">
+                        {label}
+                      </dt>
+                      <dd className="mt-1 font-medium text-stone-950">{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </section>
+            ) : null}
+
+            {listing.amenities.length > 0 ? (
+              <section className="mt-8">
+                <h2 className="text-lg font-semibold text-stone-950">Amenities</h2>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {listing.amenities.map((amenity) => (
+                    <span
+                      key={amenity}
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-stone-200 bg-surface px-3 py-1.5 text-sm text-stone-700"
+                    >
+                      <CheckIcon width={15} height={15} className="text-brand-600" />
+                      {amenity}
+                    </span>
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
+            {!isOwner && session?.user?.id ? (
+              <ContactRequestForm
+                listingId={listing.id}
+                defaultContactEmail={
+                  profileUser?.contactEmail ?? session.user.email ?? null
+                }
+                defaultContactPhone={profileUser?.contactPhone ?? null}
+              />
+            ) : null}
+
+            <ReviewSection
+              listingId={listing.id}
+              initialReviews={reviews.map(serializeReview)}
+              currentUserId={session?.user?.id ?? null}
+              isOwner={isOwner}
+            />
           </div>
+
+          {/* Sticky sidebar */}
+          <aside className="lg:sticky lg:top-24">
+            <Card className="p-6">
+              <p className="font-display text-3xl font-semibold text-stone-950">
+                ${listing.rent.toLocaleString("en-US")}
+                <span className="text-base font-normal text-stone-400">
+                  {" "}
+                  / month
+                </span>
+              </p>
+
+              <div className="mt-5 grid gap-3">
+                {isOwner ? (
+                  <>
+                    <Link
+                      href={`/listings/${listing.id}/edit`}
+                      className={buttonVariants({ className: "w-full" })}
+                    >
+                      Edit listing
+                    </Link>
+                    <ListingArchiveButton listingId={listing.id} />
+                  </>
+                ) : session?.user?.id ? (
+                  <SavedListingButton
+                    listingId={listing.id}
+                    initialSaved={isSaved}
+                  />
+                ) : (
+                  <Link
+                    href={`/login?callbackUrl=${encodeURIComponent(`/listings/${listing.id}`)}`}
+                    className={buttonVariants({
+                      variant: "secondary",
+                      className: "w-full",
+                    })}
+                  >
+                    Sign in to save
+                  </Link>
+                )}
+              </div>
+
+              {!isOwner && hasContactInfo ? (
+                <div className="mt-5 border-t border-stone-200 pt-5">
+                  <p className="text-sm font-semibold text-stone-900">
+                    Reach the poster
+                  </p>
+                  <div className="mt-3 grid gap-2">
+                    {listing.contactEmail ? (
+                      <a
+                        href={`mailto:${listing.contactEmail}?subject=${encodeURIComponent(
+                          `Interested in ${listing.title}`,
+                        )}`}
+                        className={buttonVariants({
+                          variant: "subtle",
+                          size: "sm",
+                          className: "w-full",
+                        })}
+                      >
+                        <MailIcon width={16} height={16} />
+                        Email poster
+                      </a>
+                    ) : null}
+                    {listing.contactPhone ? (
+                      <a
+                        href={`tel:${listing.contactPhone}`}
+                        className={buttonVariants({
+                          variant: "secondary",
+                          size: "sm",
+                          className: "w-full",
+                        })}
+                      >
+                        <PhoneIcon width={16} height={16} />
+                        Call or text
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+            </Card>
+          </aside>
         </div>
-      ) : null}
-
-      <ReviewSection
-        listingId={listing.id}
-        initialReviews={reviews.map(serializeReview)}
-        currentUserId={session?.user?.id ?? null}
-        isOwner={isOwner}
-      />
+      </Container>
     </main>
   );
 }

--- a/apps/web/src/app/listings/new/page.tsx
+++ b/apps/web/src/app/listings/new/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 
 import { ListingCreateForm } from "@/features/listings/components/listing-create-form";
 import { getProfileUser } from "@/features/profile/queries";
+import { Eyebrow } from "@/features/ui/card";
 import { auth } from "@/server/auth/auth";
 
 export default async function NewListingPage() {
@@ -14,14 +15,12 @@ export default async function NewListingPage() {
   const profileUser = await getProfileUser(session.user.id);
 
   return (
-    <main className="mx-auto max-w-3xl px-6 py-10">
-      <p className="text-sm font-semibold uppercase tracking-normal text-emerald-700">
-        Post listing
-      </p>
-      <h1 className="mt-3 text-3xl font-semibold text-zinc-950">
+    <main className="mx-auto w-full max-w-3xl px-5 py-10 sm:px-8 sm:py-12">
+      <Eyebrow>Post listing</Eyebrow>
+      <h1 className="mt-3 font-display text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl">
         Share an apartment or room near campus.
       </h1>
-      <p className="mt-4 leading-8 text-zinc-700">
+      <p className="mt-4 leading-8 text-stone-600">
         Add the essentials first. You can edit details after the post is live.
       </p>
       <ListingCreateForm

--- a/apps/web/src/app/listings/page.tsx
+++ b/apps/web/src/app/listings/page.tsx
@@ -13,6 +13,9 @@ import {
   type ListingQueryInput,
 } from "@/features/listings/schemas";
 import { getSavedListingIdsByUser } from "@/features/saved-listings/queries";
+import { buttonVariants } from "@/features/ui/button";
+import { Eyebrow } from "@/features/ui/card";
+import { Container } from "@/features/ui/container";
 import { auth } from "@/server/auth/auth";
 
 export const dynamic = "force-dynamic";
@@ -45,48 +48,55 @@ export default async function ListingsPage({ searchParams }: ListingsPageProps) 
     : [];
   const savedListingIdSet = new Set(savedListingIds);
 
+  const resultLabel = `${listings.length} ${
+    listings.length === 1 ? "place" : "places"
+  } available`;
+
   return (
-    <main className="mx-auto max-w-6xl px-6 py-10">
-      <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-semibold text-zinc-950">Listings</h1>
-          <p className="mt-2 text-zinc-600">
-            Apartments and rooms available near campus.
-          </p>
+    <main className="py-10 sm:py-12">
+      <Container>
+        <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <Eyebrow>Browse</Eyebrow>
+            <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl">
+              Listings near campus
+            </h1>
+            <p className="mt-2 text-stone-600">{resultLabel}</p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <button
+              form={LISTING_FILTER_FORM_ID}
+              type="submit"
+              className={buttonVariants()}
+            >
+              Apply filters
+            </button>
+            <Link
+              href="/listings"
+              className={buttonVariants({ variant: "secondary" })}
+            >
+              Clear
+            </Link>
+          </div>
         </div>
-        <div className="flex flex-wrap gap-3">
-          <button
-            form={LISTING_FILTER_FORM_ID}
-            type="submit"
-            className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
-          >
-            Apply filters
-          </button>
-          <Link
-            href="/listings"
-            className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-950 hover:bg-zinc-100"
-          >
-            Clear
-          </Link>
-        </div>
-      </div>
 
-      <ListingFilterForm key={filterComponentKey(filters)} filters={filters} />
+        <ListingFilterForm key={filterComponentKey(filters)} filters={filters} />
 
-      {listings.length === 0 ? (
-        <ListingEmptyState />
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {listings.map((listing) => (
-            <ListingCard
-              key={listing.id}
-              listing={listing}
-              isSaved={savedListingIdSet.has(listing.id)}
-              showSaveAction={Boolean(session?.user?.id)}
-            />
-          ))}
-        </div>
-      )}
+        {listings.length === 0 ? (
+          <ListingEmptyState />
+        ) : (
+          <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {listings.map((listing) => (
+              <ListingCard
+                key={listing.id}
+                listing={listing}
+                isSaved={savedListingIdSet.has(listing.id)}
+                showSaveAction={Boolean(session?.user?.id)}
+              />
+            ))}
+          </div>
+        )}
+      </Container>
     </main>
   );
 }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 
 import { resolveAuthCallbackUrl } from "@/features/auth/callback-url";
 import { LoginForm } from "@/features/auth/components/login-form";
+import { Eyebrow } from "@/features/ui/card";
 import { auth } from "@/server/auth/auth";
 
 type LoginPageProps = {
@@ -19,14 +20,12 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   }
 
   return (
-    <main className="mx-auto w-full max-w-md px-6 py-12">
-      <p className="text-sm font-semibold uppercase tracking-normal text-emerald-700">
-        Welcome back
-      </p>
-      <h1 className="mt-3 text-3xl font-semibold text-zinc-950">
+    <main className="mx-auto my-16 w-[calc(100%-2.5rem)] max-w-md rounded-2xl border border-stone-200/80 bg-surface p-8 shadow-[var(--shadow-soft)] sm:my-24 sm:p-10">
+      <Eyebrow>Welcome back</Eyebrow>
+      <h1 className="mt-3 font-display text-3xl font-semibold tracking-tight text-stone-950">
         Sign in to AllApartments
       </h1>
-      <p className="mt-3 leading-7 text-zinc-600">
+      <p className="mt-3 leading-7 text-stone-600">
         Use your email and password to post and manage housing leads.
       </p>
       <LoginForm callbackUrl={callbackUrl} />

--- a/apps/web/src/app/nav-link.tsx
+++ b/apps/web/src/app/nav-link.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/features/ui/cn";
+
+type NavLinkProps = {
+  href: string;
+  children: React.ReactNode;
+};
+
+/**
+ * Top-nav link with an active treatment derived from the current path.
+ * Keeps `href` as a direct prop so server-side nav tests can discover it.
+ */
+export function NavLink({ href, children }: NavLinkProps) {
+  const pathname = usePathname();
+  const isActive =
+    href === "/" ? pathname === "/" : pathname.startsWith(href);
+
+  return (
+    <Link
+      href={href}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "relative rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+        isActive
+          ? "text-brand-900"
+          : "text-stone-600 hover:text-stone-950",
+      )}
+    >
+      {children}
+      <span
+        className={cn(
+          "absolute inset-x-3 -bottom-px h-0.5 rounded-full bg-brand-600 transition-opacity",
+          isActive ? "opacity-100" : "opacity-0",
+        )}
+      />
+    </Link>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,35 +1,203 @@
 import Link from "next/link";
 
+import { buttonVariants } from "@/features/ui/button";
+import { Card, Eyebrow } from "@/features/ui/card";
+import { Container } from "@/features/ui/container";
+import {
+  ArrowRightIcon,
+  BedIcon,
+  HeartIcon,
+  HomeMarkIcon,
+  PinIcon,
+} from "@/features/ui/icons";
+
+const FEATURES = [
+  {
+    icon: BedIcon,
+    title: "Every kind of place",
+    body: "Full apartments, private rooms, and roommate leads — all on one warm, easy board.",
+  },
+  {
+    icon: PinIcon,
+    title: "Filter to your fit",
+    body: "Narrow by price, beds, baths, move-in date, and pet policy until it feels like home.",
+  },
+  {
+    icon: HeartIcon,
+    title: "Save & compare",
+    body: "Keep a shortlist of the places you love and revisit them whenever you're ready.",
+  },
+];
+
+const STEPS = [
+  {
+    step: "01",
+    title: "Browse the board",
+    body: "Search active listings near campus and open the ones that catch your eye.",
+  },
+  {
+    step: "02",
+    title: "Reach out safely",
+    body: "Send a structured contact request — no public phone numbers required.",
+  },
+  {
+    step: "03",
+    title: "Post your own place",
+    body: "List an apartment, room, or roommate lead in minutes and manage it from your profile.",
+  },
+];
+
 export default function Home() {
   return (
-    <main className="mx-auto flex min-h-screen max-w-5xl flex-col px-6 py-12">
-      <section className="grid flex-1 content-center gap-8">
-        <div className="space-y-4">
-          <p className="text-sm font-semibold uppercase tracking-normal text-emerald-700">
-            AllApartments
-          </p>
-          <h1 className="max-w-3xl text-4xl font-semibold tracking-normal text-zinc-950 sm:text-6xl">
-            Find apartments, rooms, and roommate leads near campus.
-          </h1>
-          <p className="max-w-2xl text-lg leading-8 text-zinc-700">
-            A local-first rental board for browsing trusted housing posts,
-            comparing rent, and contacting posters safely.
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-3">
-          <Link
-            href="/listings"
-            className="rounded-md bg-zinc-950 px-5 py-3 text-sm font-medium text-white hover:bg-zinc-800"
-          >
-            Browse listings
-          </Link>
-          <Link
-            href="/listings/new"
-            className="rounded-md border border-zinc-300 px-5 py-3 text-sm font-medium text-zinc-950 hover:bg-zinc-100"
-          >
-            Post a place
-          </Link>
-        </div>
+    <main>
+      {/* Hero */}
+      <section className="surface-grain border-b border-stone-200/60">
+        <Container>
+          <div className="grid items-center gap-12 py-16 sm:py-24 lg:grid-cols-[1.1fr_0.9fr]">
+            <div className="space-y-7">
+              <span className="inline-flex items-center gap-2 rounded-full border border-brand-200 bg-brand-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-brand-700">
+                <HomeMarkIcon width={14} height={14} />
+                Local-first housing
+              </span>
+              <h1 className="font-display text-4xl font-semibold leading-[1.05] tracking-tight text-stone-950 sm:text-6xl">
+                Find a place that
+                <span className="text-brand-700"> feels like home.</span>
+              </h1>
+              <p className="max-w-xl text-lg leading-8 text-stone-600">
+                Browse trusted apartments, rooms, and roommate leads near
+                campus. Compare rent, save your favorites, and reach posters
+                without the noise.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <Link href="/listings" className={buttonVariants({ size: "lg" })}>
+                  Browse listings
+                  <ArrowRightIcon width={18} height={18} />
+                </Link>
+                <Link
+                  href="/listings/new"
+                  className={buttonVariants({ variant: "secondary", size: "lg" })}
+                >
+                  Post a place
+                </Link>
+              </div>
+              <dl className="flex flex-wrap gap-x-10 gap-y-4 pt-4">
+                {[
+                  ["3 in 1", "Apartments · rooms · roommates"],
+                  ["Free", "To browse and to post"],
+                  ["Local", "Built around campus life"],
+                ].map(([stat, label]) => (
+                  <div key={label}>
+                    <dt className="font-display text-2xl font-semibold text-stone-950">
+                      {stat}
+                    </dt>
+                    <dd className="text-sm text-stone-500">{label}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+
+            {/* Hero visual — a warm stacked "listing" motif, pure CSS */}
+            <div className="relative hidden lg:block" aria-hidden="true">
+              <div className="absolute -right-4 top-6 h-64 w-64 rounded-full bg-brand-200/50 blur-3xl" />
+              <Card className="relative overflow-hidden p-0">
+                <div className="flex h-44 items-end bg-gradient-to-br from-brand-300 via-brand-400 to-brand-700 p-5">
+                  <span className="rounded-full bg-white/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand-900">
+                    Apartment
+                  </span>
+                </div>
+                <div className="space-y-3 p-6">
+                  <div className="flex items-baseline justify-between">
+                    <p className="font-display text-lg font-semibold text-stone-950">
+                      Sunny 2BR near campus
+                    </p>
+                    <p className="font-semibold text-brand-800">$1,150</p>
+                  </div>
+                  <p className="text-sm text-stone-500">
+                    2 bed · 1 bath · 0.4 mi to campus
+                  </p>
+                  <div className="flex gap-2 pt-1">
+                    {["Laundry", "Parking", "Furnished"].map((tag) => (
+                      <span
+                        key={tag}
+                        className="rounded-lg bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-600"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </Card>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      {/* Features */}
+      <section className="py-16 sm:py-20">
+        <Container>
+          <div className="max-w-2xl">
+            <Eyebrow>Why AllApartments</Eyebrow>
+            <h2 className="mt-3 font-display text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl">
+              Housing search, minus the headache.
+            </h2>
+          </div>
+          <div className="mt-10 grid gap-5 sm:grid-cols-3">
+            {FEATURES.map((feature) => (
+              <Card key={feature.title} className="p-6" interactive>
+                <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-brand-100 text-brand-800">
+                  <feature.icon width={22} height={22} />
+                </span>
+                <h3 className="mt-4 text-lg font-semibold text-stone-950">
+                  {feature.title}
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-stone-600">
+                  {feature.body}
+                </p>
+              </Card>
+            ))}
+          </div>
+        </Container>
+      </section>
+
+      {/* How it works */}
+      <section className="pb-16 sm:pb-24">
+        <Container>
+          <Card className="surface-grain overflow-hidden p-8 sm:p-12">
+            <div className="max-w-2xl">
+              <Eyebrow>How it works</Eyebrow>
+              <h2 className="mt-3 font-display text-3xl font-semibold tracking-tight text-stone-950">
+                Three steps to your next place.
+              </h2>
+            </div>
+            <ol className="mt-10 grid gap-8 sm:grid-cols-3">
+              {STEPS.map((item) => (
+                <li key={item.step}>
+                  <span className="font-display text-3xl font-semibold text-brand-300">
+                    {item.step}
+                  </span>
+                  <h3 className="mt-3 text-lg font-semibold text-stone-950">
+                    {item.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6 text-stone-600">
+                    {item.body}
+                  </p>
+                </li>
+              ))}
+            </ol>
+            <div className="mt-10 flex flex-wrap gap-3">
+              <Link href="/listings" className={buttonVariants()}>
+                Start browsing
+                <ArrowRightIcon width={18} height={18} />
+              </Link>
+              <Link
+                href="/register"
+                className={buttonVariants({ variant: "secondary" })}
+              >
+                Create an account
+              </Link>
+            </div>
+          </Card>
+        </Container>
       </section>
     </main>
   );

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -17,6 +17,8 @@ import { getListingsByOwner } from "@/features/listings/queries";
 import { ProfileAccountForm } from "@/features/profile/components/profile-account-form";
 import { getProfileUser } from "@/features/profile/queries";
 import { getSavedListingsByUser } from "@/features/saved-listings/queries";
+import { buttonVariants } from "@/features/ui/button";
+import { Container } from "@/features/ui/container";
 import { auth } from "@/server/auth/auth";
 
 export const dynamic = "force-dynamic";
@@ -35,34 +37,34 @@ function renderProfileListingRow(listing: Listing) {
   return (
     <article
       key={listing.id}
-      className="grid gap-4 rounded-md border border-zinc-200 p-4 md:grid-cols-[1fr_auto] md:items-center"
+      className="grid gap-4 rounded-2xl border border-stone-200/80 bg-surface p-5 shadow-[var(--shadow-soft)] md:grid-cols-[1fr_auto] md:items-center"
     >
       <div>
         <div className="flex flex-wrap items-center gap-2">
-          <span className="rounded-md border border-zinc-200 px-2 py-1 text-xs font-medium text-zinc-700">
+          <span className="rounded-full border border-stone-300 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-stone-600">
             {listing.type}
           </span>
-          <span className="rounded-md bg-zinc-100 px-2 py-1 text-xs font-medium text-zinc-700">
+          <span className="rounded-full bg-brand-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-brand-900">
             {listing.status}
           </span>
         </div>
-        <h2 className="mt-3 text-lg font-semibold text-zinc-950">
+        <h2 className="mt-3 text-lg font-semibold text-stone-950">
           {listing.title}
         </h2>
-        <p className="mt-1 text-sm text-zinc-600">
+        <p className="mt-1 text-sm text-stone-600">
           ${listing.rent}/month · Updated {formatDate(listing.updatedAt)}
         </p>
       </div>
       <div className="flex flex-wrap gap-2">
         <Link
           href={`/listings/${listing.id}`}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm font-medium text-zinc-950 hover:bg-zinc-100"
+          className={buttonVariants({ variant: "secondary", size: "sm" })}
         >
           View
         </Link>
         <Link
           href={`/listings/${listing.id}/edit`}
-          className="rounded-md bg-zinc-950 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+          className={buttonVariants({ size: "sm" })}
         >
           Edit
         </Link>
@@ -96,25 +98,26 @@ export default async function ProfilePage() {
   const email = profileUser?.email ?? session.user.email;
 
   return (
-    <main className="mx-auto w-full max-w-6xl px-6 py-10">
-      <section className="grid gap-6 border-b border-zinc-200 pb-8 md:grid-cols-[1fr_auto] md:items-end">
+    <main className="py-10 sm:py-12">
+      <Container>
+      <section className="grid gap-6 border-b border-stone-200 pb-8 md:grid-cols-[1fr_auto] md:items-end">
         <div>
-          <p className="text-sm font-medium uppercase text-emerald-700">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-700">
             Profile
           </p>
-          <h1 className="mt-2 text-3xl font-semibold text-zinc-950">
+          <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl">
             {displayName}
           </h1>
-          {email ? <p className="mt-2 text-zinc-600">{email}</p> : null}
+          {email ? <p className="mt-2 text-stone-600">{email}</p> : null}
           {profileUser?.createdAt ? (
-            <p className="mt-1 text-sm text-zinc-500">
+            <p className="mt-1 text-sm text-stone-500">
               {`Joined ${formatDate(profileUser.createdAt)}`}
             </p>
           ) : null}
         </div>
         <Link
           href="/listings/new"
-          className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+          className={buttonVariants({ size: "sm" })}
         >
           Post listing
         </Link>
@@ -123,10 +126,10 @@ export default async function ProfilePage() {
       {profileUser ? (
         <section className="mt-8">
           <div>
-            <h2 className="text-2xl font-semibold text-zinc-950">
+            <h2 className="font-display text-2xl font-semibold tracking-tight text-stone-950">
               Account basics
             </h2>
-            <p className="mt-1 text-sm text-zinc-600">
+            <p className="mt-1 text-sm text-stone-600">
               Keep your display name and default contact details ready for new
               listings.
             </p>
@@ -138,30 +141,30 @@ export default async function ProfilePage() {
       <section className="mt-8">
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
-            <h2 className="text-2xl font-semibold text-zinc-950">
+            <h2 className="font-display text-2xl font-semibold tracking-tight text-stone-950">
               Your listings
             </h2>
-            <p className="mt-1 text-sm text-zinc-600">
+            <p className="mt-1 text-sm text-stone-600">
               Manage active, draft, rented, and archived posts from one place.
             </p>
           </div>
-          <p className="text-sm font-medium text-zinc-500">
+          <p className="text-sm font-medium text-stone-500">
             {listings.length} total
           </p>
         </div>
 
         {listings.length === 0 ? (
-          <div className="mt-6 rounded-md border border-dashed border-zinc-300 px-6 py-10 text-center">
-            <h3 className="text-lg font-semibold text-zinc-950">
+          <div className="mt-6 rounded-2xl border border-dashed border-stone-300 bg-surface px-6 py-12 text-center">
+            <h3 className="text-lg font-semibold text-stone-950">
               No listings yet
             </h3>
-            <p className="mx-auto mt-2 max-w-md text-sm text-zinc-600">
+            <p className="mx-auto mt-2 max-w-md text-sm text-stone-600">
               Post your first apartment, room, or roommate lead so renters can
               find it near campus.
             </p>
             <Link
               href="/listings/new"
-              className="mt-5 inline-flex rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+              className={buttonVariants({ className: "mt-5" })}
             >
               Post your first listing
             </Link>
@@ -184,30 +187,30 @@ export default async function ProfilePage() {
       <section className="mt-8">
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
-            <h2 className="text-2xl font-semibold text-zinc-950">
+            <h2 className="font-display text-2xl font-semibold tracking-tight text-stone-950">
               Saved listings
             </h2>
-            <p className="mt-1 text-sm text-zinc-600">
+            <p className="mt-1 text-sm text-stone-600">
               Keep track of apartments and rooms you want to revisit.
             </p>
           </div>
-          <p className="text-sm font-medium text-zinc-500">
+          <p className="text-sm font-medium text-stone-500">
             {savedListings.length} saved
           </p>
         </div>
 
         {savedListings.length === 0 ? (
-          <div className="mt-6 rounded-md border border-dashed border-zinc-300 px-6 py-10 text-center">
-            <h3 className="text-lg font-semibold text-zinc-950">
+          <div className="mt-6 rounded-2xl border border-dashed border-stone-300 bg-surface px-6 py-12 text-center">
+            <h3 className="text-lg font-semibold text-stone-950">
               No saved listings yet
             </h3>
-            <p className="mx-auto mt-2 max-w-md text-sm text-zinc-600">
+            <p className="mx-auto mt-2 max-w-md text-sm text-stone-600">
               Save listings from the browse page or listing details when you
               want to compare them later.
             </p>
             <Link
               href="/listings"
-              className="mt-5 inline-flex rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+              className={buttonVariants({ className: "mt-5" })}
             >
               Browse listings
             </Link>
@@ -225,6 +228,7 @@ export default async function ProfilePage() {
           </div>
         )}
       </section>
+      </Container>
     </main>
   );
 }

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 
 import { resolveAuthCallbackUrl } from "@/features/auth/callback-url";
 import { RegisterForm } from "@/features/auth/components/register-form";
+import { Eyebrow } from "@/features/ui/card";
 import { auth } from "@/server/auth/auth";
 
 type RegisterPageProps = {
@@ -19,14 +20,12 @@ export default async function RegisterPage({ searchParams }: RegisterPageProps) 
   }
 
   return (
-    <main className="mx-auto w-full max-w-md px-6 py-12">
-      <p className="text-sm font-semibold uppercase tracking-normal text-emerald-700">
-        Create account
-      </p>
-      <h1 className="mt-3 text-3xl font-semibold text-zinc-950">
+    <main className="mx-auto my-16 w-[calc(100%-2.5rem)] max-w-md rounded-2xl border border-stone-200/80 bg-surface p-8 shadow-[var(--shadow-soft)] sm:my-24 sm:p-10">
+      <Eyebrow>Create account</Eyebrow>
+      <h1 className="mt-3 font-display text-3xl font-semibold tracking-tight text-stone-950">
         Join AllApartments
       </h1>
-      <p className="mt-3 leading-7 text-zinc-600">
+      <p className="mt-3 leading-7 text-stone-600">
         Create a local account to post listings and keep ownership tied to you.
       </p>
       <RegisterForm callbackUrl={callbackUrl} />

--- a/apps/web/src/features/auth/components/login-form.tsx
+++ b/apps/web/src/features/auth/components/login-form.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 
+import { buttonVariants } from "@/features/ui/button";
+import { fieldInput, fieldLabel } from "@/features/ui/field";
 import { FormFeedback } from "@/features/ui/form-feedback";
 
 type LoginFormProps = {
@@ -103,7 +105,7 @@ export function LoginForm({ callbackUrl }: LoginFormProps) {
       ) : null}
 
       <div className="grid gap-2">
-        <label htmlFor="email" className="text-sm font-medium text-zinc-800">
+        <label htmlFor="email" className={fieldLabel()}>
           Email
         </label>
         <input
@@ -113,12 +115,12 @@ export function LoginForm({ callbackUrl }: LoginFormProps) {
           required
           autoComplete="email"
           disabled={isSubmitting}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldInput()}
         />
       </div>
 
       <div className="grid gap-2">
-        <label htmlFor="password" className="text-sm font-medium text-zinc-800">
+        <label htmlFor="password" className={fieldLabel()}>
           Password
         </label>
         <input
@@ -128,23 +130,23 @@ export function LoginForm({ callbackUrl }: LoginFormProps) {
           required
           autoComplete="current-password"
           disabled={isSubmitting}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldInput()}
         />
       </div>
 
       <button
         type="submit"
         disabled={isSubmitting}
-        className="rounded-md bg-zinc-950 px-5 py-3 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+        className={buttonVariants({ size: "lg", className: "w-full" })}
       >
         {isSubmitting ? "Signing in..." : "Sign in"}
       </button>
 
-      <p className="text-sm text-zinc-600">
+      <p className="text-sm text-stone-600">
         Need an account?{" "}
         <Link
           href={`/register?callbackUrl=${encodeURIComponent(callbackUrl)}`}
-          className="font-medium text-zinc-950 underline-offset-4 hover:underline"
+          className="font-semibold text-brand-700 underline-offset-4 hover:underline"
         >
           Create one
         </Link>

--- a/apps/web/src/features/auth/components/register-form.tsx
+++ b/apps/web/src/features/auth/components/register-form.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 
+import { buttonVariants } from "@/features/ui/button";
+import { fieldInput, fieldLabel } from "@/features/ui/field";
 import { FormFeedback } from "@/features/ui/form-feedback";
 
 type ApiErrorBody = {
@@ -138,7 +140,7 @@ export function RegisterForm({ callbackUrl }: RegisterFormProps) {
       ) : null}
 
       <div className="grid gap-2">
-        <label htmlFor="name" className="text-sm font-medium text-zinc-800">
+        <label htmlFor="name" className={fieldLabel()}>
           Name
         </label>
         <input
@@ -148,12 +150,12 @@ export function RegisterForm({ callbackUrl }: RegisterFormProps) {
           minLength={2}
           autoComplete="name"
           disabled={isSubmitting}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldInput()}
         />
       </div>
 
       <div className="grid gap-2">
-        <label htmlFor="email" className="text-sm font-medium text-zinc-800">
+        <label htmlFor="email" className={fieldLabel()}>
           Email
         </label>
         <input
@@ -163,12 +165,12 @@ export function RegisterForm({ callbackUrl }: RegisterFormProps) {
           required
           autoComplete="email"
           disabled={isSubmitting}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldInput()}
         />
       </div>
 
       <div className="grid gap-2">
-        <label htmlFor="password" className="text-sm font-medium text-zinc-800">
+        <label htmlFor="password" className={fieldLabel()}>
           Password
         </label>
         <input
@@ -179,23 +181,23 @@ export function RegisterForm({ callbackUrl }: RegisterFormProps) {
           minLength={8}
           autoComplete="new-password"
           disabled={isSubmitting}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldInput()}
         />
       </div>
 
       <button
         type="submit"
         disabled={isSubmitting}
-        className="rounded-md bg-zinc-950 px-5 py-3 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+        className={buttonVariants({ size: "lg", className: "w-full" })}
       >
         {isSubmitting ? "Creating account..." : "Create account"}
       </button>
 
-      <p className="text-sm text-zinc-600">
+      <p className="text-sm text-stone-600">
         Already have an account?{" "}
         <Link
           href={`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`}
-          className="font-medium text-zinc-950 underline-offset-4 hover:underline"
+          className="font-semibold text-brand-700 underline-offset-4 hover:underline"
         >
           Sign in
         </Link>

--- a/apps/web/src/features/contact-requests/components/contact-request-form.tsx
+++ b/apps/web/src/features/contact-requests/components/contact-request-form.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 
 import { type ContactRequestCreateInput } from "@/features/contact-requests/schemas";
+import { buttonVariants } from "@/features/ui/button";
+import { fieldInput, fieldLabel, fieldSelect, fieldTextarea } from "@/features/ui/field";
 import { FormFeedback } from "@/features/ui/form-feedback";
 
 type ApiErrorBody = {
@@ -114,11 +116,9 @@ export function ContactRequestForm({
   }
 
   return (
-    <section className="mt-8 rounded-md border border-emerald-200 bg-emerald-50 px-5 py-4">
-      <h2 className="text-lg font-semibold text-emerald-950">
-        Contact poster
-      </h2>
-      <p className="mt-1 text-sm text-emerald-900">
+    <section className="mt-8 rounded-2xl border border-brand-200/70 bg-brand-50/60 p-6 shadow-[var(--shadow-soft)]">
+      <h2 className="text-lg font-semibold text-stone-950">Contact poster</h2>
+      <p className="mt-1 text-sm text-stone-600">
         Send a structured request so the poster can review it from their
         profile.
       </p>
@@ -132,7 +132,7 @@ export function ContactRequestForm({
         ) : null}
 
         <div className="grid gap-2">
-          <label htmlFor="message" className="text-sm font-medium text-emerald-950">
+          <label htmlFor="message" className={fieldLabel()}>
             Message
           </label>
           <textarea
@@ -140,7 +140,7 @@ export function ContactRequestForm({
             name="message"
             required
             rows={4}
-            className="rounded-md border border-emerald-300 px-3 py-2 text-sm outline-none focus:border-emerald-900"
+            className={fieldTextarea()}
             placeholder="Share your timing, questions, or tour availability."
           />
         </div>
@@ -149,7 +149,7 @@ export function ContactRequestForm({
           <div className="grid gap-2">
             <label
               htmlFor="preferredContactMethod"
-              className="text-sm font-medium text-emerald-950"
+              className={fieldLabel()}
             >
               Preferred contact
             </label>
@@ -157,7 +157,7 @@ export function ContactRequestForm({
               id="preferredContactMethod"
               name="preferredContactMethod"
               defaultValue="ANY"
-              className="rounded-md border border-emerald-300 px-3 py-2 text-sm outline-none focus:border-emerald-900"
+              className={fieldSelect()}
             >
               <option value="ANY">Any</option>
               <option value="EMAIL">Email</option>
@@ -168,7 +168,7 @@ export function ContactRequestForm({
           <div className="grid gap-2">
             <label
               htmlFor="contactEmail"
-              className="text-sm font-medium text-emerald-950"
+              className={fieldLabel()}
             >
               Contact email
             </label>
@@ -177,14 +177,14 @@ export function ContactRequestForm({
               name="contactEmail"
               type="email"
               defaultValue={defaultContactEmail ?? ""}
-              className="rounded-md border border-emerald-300 px-3 py-2 text-sm outline-none focus:border-emerald-900"
+              className={fieldInput()}
             />
           </div>
 
           <div className="grid gap-2">
             <label
               htmlFor="contactPhone"
-              className="text-sm font-medium text-emerald-950"
+              className={fieldLabel()}
             >
               Contact phone
             </label>
@@ -193,7 +193,7 @@ export function ContactRequestForm({
               name="contactPhone"
               type="tel"
               defaultValue={defaultContactPhone ?? ""}
-              className="rounded-md border border-emerald-300 px-3 py-2 text-sm outline-none focus:border-emerald-900"
+              className={fieldInput()}
             />
           </div>
         </div>
@@ -201,7 +201,7 @@ export function ContactRequestForm({
         <button
           type="submit"
           disabled={isSubmitting}
-          className="w-fit rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+          className={buttonVariants({ className: "w-fit" })}
         >
           {isSubmitting ? "Sending..." : "Send request"}
         </button>

--- a/apps/web/src/features/contact-requests/components/contact-request-lists.tsx
+++ b/apps/web/src/features/contact-requests/components/contact-request-lists.tsx
@@ -33,24 +33,24 @@ export function ContactRequestsReceivedList({
     <section className="mt-8">
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 className="text-2xl font-semibold text-zinc-950">
+          <h2 className="text-2xl font-semibold text-stone-950">
             Requests received
           </h2>
-          <p className="mt-1 text-sm text-zinc-600">
+          <p className="mt-1 text-sm text-stone-600">
             Review renter interest across your listings.
           </p>
         </div>
-        <p className="text-sm font-medium text-zinc-500">
+        <p className="text-sm font-medium text-stone-500">
           {contactRequests.length} total
         </p>
       </div>
 
       {contactRequests.length === 0 ? (
-        <div className="mt-6 rounded-md border border-dashed border-zinc-300 px-6 py-8 text-center">
-          <h3 className="text-lg font-semibold text-zinc-950">
+        <div className="mt-6 rounded-md border border-dashed border-stone-300 px-6 py-8 text-center">
+          <h3 className="text-lg font-semibold text-stone-950">
             No requests received yet
           </h3>
-          <p className="mx-auto mt-2 max-w-md text-sm text-zinc-600">
+          <p className="mx-auto mt-2 max-w-md text-sm text-stone-600">
             Requests from renters will show up here after they contact you from
             a listing.
           </p>
@@ -60,33 +60,33 @@ export function ContactRequestsReceivedList({
           {contactRequests.map((request) => (
             <article
               key={request.id}
-              className="rounded-md border border-zinc-200 p-4"
+              className="rounded-2xl border border-stone-200/80 bg-surface p-5 shadow-[var(--shadow-soft)]"
             >
               <div className="flex flex-wrap justify-between gap-3">
                 <div>
                   <h3 className="font-semibold">
                     <Link
                       href={`/listings/${request.listingId}`}
-                      className="text-zinc-950 underline-offset-4 hover:underline"
+                      className="text-stone-950 underline-offset-4 hover:underline"
                     >
                       {request.listingTitle}
                     </Link>
                   </h3>
-                  <p className="mt-1 text-sm text-zinc-600">
+                  <p className="mt-1 text-sm text-stone-600">
                     From {request.requesterName ?? request.requesterEmail ?? "Renter"}
                   </p>
                 </div>
-                <p className="text-sm text-zinc-500">
+                <p className="text-sm text-stone-500">
                   {formatDate(request.createdAt)}
                 </p>
               </div>
-              <p className="mt-3 text-sm leading-6 text-zinc-700">
+              <p className="mt-3 text-sm leading-6 text-stone-700">
                 {request.message}
               </p>
-              <p className="mt-3 text-sm font-medium text-zinc-950">
+              <p className="mt-3 text-sm font-medium text-stone-950">
                 Preferred contact: {methodLabel(request.preferredContactMethod)}
               </p>
-              <p className="mt-1 text-sm text-zinc-600">
+              <p className="mt-1 text-sm text-stone-600">
                 {[request.contactEmail, request.contactPhone].filter(Boolean).join(" · ")}
               </p>
             </article>
@@ -104,24 +104,24 @@ export function ContactRequestsSentList({
     <section className="mt-8">
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 className="text-2xl font-semibold text-zinc-950">
+          <h2 className="text-2xl font-semibold text-stone-950">
             Requests sent
           </h2>
-          <p className="mt-1 text-sm text-zinc-600">
+          <p className="mt-1 text-sm text-stone-600">
             Track the listings you contacted from the app.
           </p>
         </div>
-        <p className="text-sm font-medium text-zinc-500">
+        <p className="text-sm font-medium text-stone-500">
           {contactRequests.length} total
         </p>
       </div>
 
       {contactRequests.length === 0 ? (
-        <div className="mt-6 rounded-md border border-dashed border-zinc-300 px-6 py-8 text-center">
-          <h3 className="text-lg font-semibold text-zinc-950">
+        <div className="mt-6 rounded-md border border-dashed border-stone-300 px-6 py-8 text-center">
+          <h3 className="text-lg font-semibold text-stone-950">
             No requests sent yet
           </h3>
-          <p className="mx-auto mt-2 max-w-md text-sm text-zinc-600">
+          <p className="mx-auto mt-2 max-w-md text-sm text-stone-600">
             Contact a poster from a listing detail page and your request will
             appear here.
           </p>
@@ -131,30 +131,30 @@ export function ContactRequestsSentList({
           {contactRequests.map((request) => (
             <article
               key={request.id}
-              className="rounded-md border border-zinc-200 p-4"
+              className="rounded-2xl border border-stone-200/80 bg-surface p-5 shadow-[var(--shadow-soft)]"
             >
               <div className="flex flex-wrap justify-between gap-3">
                 <div>
                   <h3 className="font-semibold">
                     <Link
                       href={`/listings/${request.listingId}`}
-                      className="text-zinc-950 underline-offset-4 hover:underline"
+                      className="text-stone-950 underline-offset-4 hover:underline"
                     >
                       {request.listingTitle}
                     </Link>
                   </h3>
-                  <p className="mt-1 text-sm text-zinc-600">
+                  <p className="mt-1 text-sm text-stone-600">
                     To {request.ownerName ?? request.ownerEmail ?? "Owner"}
                   </p>
                 </div>
-                <p className="text-sm text-zinc-500">
+                <p className="text-sm text-stone-500">
                   {formatDate(request.createdAt)}
                 </p>
               </div>
-              <p className="mt-3 text-sm leading-6 text-zinc-700">
+              <p className="mt-3 text-sm leading-6 text-stone-700">
                 {request.message}
               </p>
-              <p className="mt-3 text-sm font-medium text-zinc-950">
+              <p className="mt-3 text-sm font-medium text-stone-950">
                 Preferred contact: {methodLabel(request.preferredContactMethod)}
               </p>
             </article>

--- a/apps/web/src/features/listings/components/listing-archive-button.tsx
+++ b/apps/web/src/features/listings/components/listing-archive-button.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+import { buttonVariants } from "@/features/ui/button";
 import { FormFeedback } from "@/features/ui/form-feedback";
 
 type ListingArchiveButtonProps = {
@@ -52,7 +53,7 @@ export function ListingArchiveButton({ listingId }: ListingArchiveButtonProps) {
         type="button"
         onClick={archiveListing}
         disabled={isArchiving}
-        className="rounded-md border border-red-200 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:text-red-300"
+        className={buttonVariants({ variant: "danger", className: "w-full" })}
       >
         {isArchiving ? "Archiving..." : "Archive"}
       </button>

--- a/apps/web/src/features/listings/components/listing-card.tsx
+++ b/apps/web/src/features/listings/components/listing-card.tsx
@@ -2,12 +2,18 @@ import type { Listing } from "@prisma/client";
 import Link from "next/link";
 
 import { SavedListingButton } from "@/features/saved-listings/components/saved-listing-button";
+import { Badge, listingTypeLabel } from "@/features/ui/badge";
+import { BedIcon, BathIcon, PinIcon } from "@/features/ui/icons";
 
 type ListingCardProps = {
   listing: Listing;
   isSaved?: boolean;
   showSaveAction?: boolean;
 };
+
+function formatRent(rent: number) {
+  return `$${rent.toLocaleString("en-US")}`;
+}
 
 export function ListingCard({
   listing,
@@ -18,31 +24,85 @@ export function ListingCard({
     listing.type === "ROOMMATE"
       ? listing.lifestyle ?? listing.roommatePreferences ?? listing.preferredGender
       : null;
+  const coverImage = listing.imageUrls[0];
+
+  const meta = [
+    listing.bedrooms !== null
+      ? { icon: BedIcon, label: `${listing.bedrooms} bed` }
+      : null,
+    listing.bathrooms !== null
+      ? { icon: BathIcon, label: `${listing.bathrooms} bath` }
+      : null,
+    listing.distanceToCampus
+      ? { icon: PinIcon, label: listing.distanceToCampus }
+      : null,
+  ].filter((item): item is { icon: typeof BedIcon; label: string } =>
+    Boolean(item),
+  );
 
   return (
-    <article className="grid gap-4 rounded-md border border-zinc-200 p-4 transition hover:border-zinc-400">
+    <article className="group flex flex-col overflow-hidden rounded-2xl border border-stone-200/80 bg-surface shadow-[var(--shadow-soft)] transition-all duration-200 hover:-translate-y-0.5 hover:border-brand-200 hover:shadow-[var(--shadow-lift)]">
       <Link href={`/listings/${listing.id}`} className="block">
-        <div className="text-xs font-medium uppercase text-emerald-700">
-          {listing.type}
+        <div className="relative aspect-[16/10] w-full overflow-hidden bg-brand-100">
+          {coverImage ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={coverImage}
+              alt={listing.title}
+              className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-brand-200 via-brand-300 to-brand-500 text-brand-900/70">
+              <PinIcon width={32} height={32} />
+            </div>
+          )}
+          <div className="absolute left-3 top-3">
+            <Badge tone="brand" className="shadow-sm backdrop-blur">
+              {listingTypeLabel(listing.type)}
+            </Badge>
+          </div>
         </div>
-        <h2 className="mt-2 text-lg font-semibold text-zinc-950">
-          {listing.title}
-        </h2>
-        <p className="mt-2 line-clamp-2 text-sm text-zinc-600">
-          {listing.description}
-        </p>
+      </Link>
+
+      <div className="flex flex-1 flex-col p-5">
+        <Link href={`/listings/${listing.id}`} className="block">
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="text-base font-semibold leading-snug text-stone-950 group-hover:text-brand-800">
+              {listing.title}
+            </h2>
+            <p className="shrink-0 font-display text-lg font-semibold text-brand-800">
+              {formatRent(listing.rent)}
+              <span className="text-xs font-normal text-stone-400">/mo</span>
+            </p>
+          </div>
+          <p className="mt-2 line-clamp-2 text-sm leading-6 text-stone-600">
+            {listing.description}
+          </p>
+        </Link>
+
+        {meta.length > 0 ? (
+          <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-stone-500">
+            {meta.map((item) => (
+              <span key={item.label} className="inline-flex items-center gap-1.5">
+                <item.icon width={16} height={16} className="text-brand-500" />
+                {item.label}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
         {roommateCue ? (
-          <p className="mt-3 text-sm font-medium text-emerald-800">
+          <p className="mt-3 rounded-lg bg-brand-50 px-3 py-2 text-sm font-medium text-brand-800">
             {roommateCue}
           </p>
         ) : null}
-        <p className="mt-4 font-medium text-zinc-950">${listing.rent}/month</p>
-      </Link>
-      {showSaveAction ? (
-        <div className="flex justify-end">
-          <SavedListingButton listingId={listing.id} initialSaved={isSaved} />
-        </div>
-      ) : null}
+
+        {showSaveAction ? (
+          <div className="mt-auto flex justify-end pt-4">
+            <SavedListingButton listingId={listing.id} initialSaved={isSaved} />
+          </div>
+        ) : null}
+      </div>
     </article>
   );
 }

--- a/apps/web/src/features/listings/components/listing-create-form.tsx
+++ b/apps/web/src/features/listings/components/listing-create-form.tsx
@@ -10,6 +10,8 @@ import {
   LISTING_IMAGE_MAX_COUNT,
   type ListingCreateInput,
 } from "@/features/listings/schemas";
+import { buttonVariants } from "@/features/ui/button";
+import { fieldInput, fieldLabel, fieldSelect, fieldTextarea } from "@/features/ui/field";
 import { FormFeedback } from "@/features/ui/form-feedback";
 
 type ApiErrorBody = {
@@ -131,10 +133,10 @@ type RoommateFitFieldsProps = {
 
 export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
   return (
-    <section className="grid gap-4 rounded-md border border-zinc-200 p-4">
+    <section className="grid gap-4 rounded-2xl border border-stone-200/80 bg-brand-50/40 p-5">
       <div>
-        <h2 className="text-sm font-semibold text-zinc-950">Roommate fit</h2>
-        <p className="mt-1 text-sm text-zinc-600">
+        <h2 className="text-sm font-semibold text-stone-950">Roommate fit</h2>
+        <p className="mt-1 text-sm text-stone-600">
           Share compatibility details for people comparing roommate leads.
         </p>
       </div>
@@ -143,7 +145,7 @@ export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
         <div className="grid gap-2">
           <label
             htmlFor="roommateCount"
-            className="text-sm font-medium text-zinc-800"
+            className={fieldLabel()}
           >
             Roommates needed
           </label>
@@ -154,7 +156,7 @@ export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
             step="1"
             type="number"
             defaultValue={listing?.roommateCount ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="1"
           />
         </div>
@@ -162,7 +164,7 @@ export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
         <div className="grid gap-2">
           <label
             htmlFor="preferredGender"
-            className="text-sm font-medium text-zinc-800"
+            className={fieldLabel()}
           >
             Preferred gender
           </label>
@@ -170,7 +172,7 @@ export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
             id="preferredGender"
             name="preferredGender"
             defaultValue={listing?.preferredGender ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="No preference"
           />
         </div>
@@ -178,14 +180,14 @@ export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="grid gap-2">
-          <label htmlFor="lifestyle" className="text-sm font-medium text-zinc-800">
+          <label htmlFor="lifestyle" className={fieldLabel()}>
             Lifestyle
           </label>
           <input
             id="lifestyle"
             name="lifestyle"
             defaultValue={listing?.lifestyle ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="Quiet weekdays, social weekends"
           />
         </div>
@@ -193,7 +195,7 @@ export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
         <div className="grid gap-2">
           <label
             htmlFor="cleanliness"
-            className="text-sm font-medium text-zinc-800"
+            className={fieldLabel()}
           >
             Cleanliness
           </label>
@@ -201,7 +203,7 @@ export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
             id="cleanliness"
             name="cleanliness"
             defaultValue={listing?.cleanliness ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="Shared chores weekly"
           />
         </div>
@@ -210,7 +212,7 @@ export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
       <div className="grid gap-2">
         <label
           htmlFor="smokingPolicy"
-          className="text-sm font-medium text-zinc-800"
+          className={fieldLabel()}
         >
           Smoking policy
         </label>
@@ -218,7 +220,7 @@ export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
           id="smokingPolicy"
           name="smokingPolicy"
           defaultValue={listing?.smokingPolicy ?? ""}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldInput()}
           placeholder="No smoking"
         />
       </div>
@@ -226,7 +228,7 @@ export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
       <div className="grid gap-2">
         <label
           htmlFor="roommatePreferences"
-          className="text-sm font-medium text-zinc-800"
+          className={fieldLabel()}
         >
           Roommate preferences
         </label>
@@ -235,7 +237,7 @@ export function RoommateFitFields({ listing }: RoommateFitFieldsProps) {
           name="roommatePreferences"
           rows={3}
           defaultValue={listing?.roommatePreferences ?? ""}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldTextarea()}
           placeholder="Graduate students preferred"
         />
       </div>
@@ -354,7 +356,7 @@ export function ListingCreateForm({
       ) : null}
 
       <div className="grid gap-2">
-        <label htmlFor="title" className="text-sm font-medium text-zinc-800">
+        <label htmlFor="title" className={fieldLabel()}>
           Title
         </label>
         <input
@@ -362,14 +364,14 @@ export function ListingCreateForm({
           name="title"
           required
           defaultValue={listing?.title}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldInput()}
           placeholder="Sunny room near campus"
         />
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="grid gap-2">
-          <label htmlFor="type" className="text-sm font-medium text-zinc-800">
+          <label htmlFor="type" className={fieldLabel()}>
             Type
           </label>
           <select
@@ -380,7 +382,7 @@ export function ListingCreateForm({
             onChange={(event) =>
               setSelectedType(event.target.value as ListingCreateInput["type"])
             }
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldSelect()}
           >
             <option value="APARTMENT">Apartment</option>
             <option value="ROOM">Room</option>
@@ -389,7 +391,7 @@ export function ListingCreateForm({
         </div>
 
         <div className="grid gap-2">
-          <label htmlFor="rent" className="text-sm font-medium text-zinc-800">
+          <label htmlFor="rent" className={fieldLabel()}>
             Rent
           </label>
           <input
@@ -400,14 +402,14 @@ export function ListingCreateForm({
             step="1"
             type="number"
             defaultValue={listing?.rent}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="900"
           />
         </div>
       </div>
 
       <div className="grid gap-2">
-        <label htmlFor="description" className="text-sm font-medium text-zinc-800">
+        <label htmlFor="description" className={fieldLabel()}>
           Description
         </label>
         <textarea
@@ -416,14 +418,14 @@ export function ListingCreateForm({
           required
           rows={5}
           defaultValue={listing?.description}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldTextarea()}
           placeholder="Share the important details, roommate expectations, and what makes the place useful."
         />
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="grid gap-2">
-          <label htmlFor="deposit" className="text-sm font-medium text-zinc-800">
+          <label htmlFor="deposit" className={fieldLabel()}>
             Deposit
           </label>
           <input
@@ -433,7 +435,7 @@ export function ListingCreateForm({
             step="1"
             type="number"
             defaultValue={listing?.deposit ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="500"
           />
         </div>
@@ -441,7 +443,7 @@ export function ListingCreateForm({
         <div className="grid gap-2">
           <label
             htmlFor="availableFrom"
-            className="text-sm font-medium text-zinc-800"
+            className={fieldLabel()}
           >
             Available from
           </label>
@@ -450,7 +452,7 @@ export function ListingCreateForm({
             name="availableFrom"
             type="date"
             defaultValue={toDateInputValue(listing?.availableFrom)}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
           />
         </div>
       </div>
@@ -459,7 +461,7 @@ export function ListingCreateForm({
         <div className="grid gap-2">
           <label
             htmlFor="leaseDuration"
-            className="text-sm font-medium text-zinc-800"
+            className={fieldLabel()}
           >
             Lease duration
           </label>
@@ -467,7 +469,7 @@ export function ListingCreateForm({
             id="leaseDuration"
             name="leaseDuration"
             defaultValue={listing?.leaseDuration ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="12 months"
           />
         </div>
@@ -475,7 +477,7 @@ export function ListingCreateForm({
         <div className="grid gap-2">
           <label
             htmlFor="distanceToCampus"
-            className="text-sm font-medium text-zinc-800"
+            className={fieldLabel()}
           >
             Distance to campus
           </label>
@@ -483,21 +485,21 @@ export function ListingCreateForm({
             id="distanceToCampus"
             name="distanceToCampus"
             defaultValue={listing?.distanceToCampus ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="0.5 miles"
           />
         </div>
       </div>
 
       <div className="grid gap-2">
-        <label htmlFor="address" className="text-sm font-medium text-zinc-800">
+        <label htmlFor="address" className={fieldLabel()}>
           Address
         </label>
         <input
           id="address"
           name="address"
           defaultValue={listing?.address ?? ""}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldInput()}
           placeholder="720 4th Ave S"
         />
       </div>
@@ -506,7 +508,7 @@ export function ListingCreateForm({
         <div className="grid gap-2">
           <label
             htmlFor="contactEmail"
-            className="text-sm font-medium text-zinc-800"
+            className={fieldLabel()}
           >
             Contact email
           </label>
@@ -515,7 +517,7 @@ export function ListingCreateForm({
             name="contactEmail"
             type="email"
             defaultValue={listing?.contactEmail ?? defaultContactEmail ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="poster@example.com"
           />
         </div>
@@ -523,7 +525,7 @@ export function ListingCreateForm({
         <div className="grid gap-2">
           <label
             htmlFor="contactPhone"
-            className="text-sm font-medium text-zinc-800"
+            className={fieldLabel()}
           >
             Contact phone
           </label>
@@ -532,7 +534,7 @@ export function ListingCreateForm({
             name="contactPhone"
             type="tel"
             defaultValue={listing?.contactPhone ?? defaultContactPhone ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="320-555-1212"
           />
         </div>
@@ -540,7 +542,7 @@ export function ListingCreateForm({
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="grid gap-2">
-          <label htmlFor="bedrooms" className="text-sm font-medium text-zinc-800">
+          <label htmlFor="bedrooms" className={fieldLabel()}>
             Bedrooms
           </label>
           <input
@@ -550,12 +552,12 @@ export function ListingCreateForm({
             step="1"
             type="number"
             defaultValue={listing?.bedrooms ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
           />
         </div>
 
         <div className="grid gap-2">
-          <label htmlFor="bathrooms" className="text-sm font-medium text-zinc-800">
+          <label htmlFor="bathrooms" className={fieldLabel()}>
             Bathrooms
           </label>
           <input
@@ -565,20 +567,20 @@ export function ListingCreateForm({
             step="0.5"
             type="number"
             defaultValue={listing?.bathrooms ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
           />
         </div>
       </div>
 
       <div className="grid gap-2">
-        <label htmlFor="petPolicy" className="text-sm font-medium text-zinc-800">
+        <label htmlFor="petPolicy" className={fieldLabel()}>
           Pet policy
         </label>
         <select
           id="petPolicy"
           name="petPolicy"
           defaultValue={listing?.petPolicy ?? "UNKNOWN"}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldSelect()}
         >
           <option value="UNKNOWN">Not specified</option>
           <option value="PETS_ALLOWED">Pets allowed</option>
@@ -588,12 +590,12 @@ export function ListingCreateForm({
         </select>
       </div>
 
-      <label className="flex items-center gap-3 text-sm font-medium text-zinc-800">
+      <label className="flex items-center gap-3 text-sm font-medium text-stone-800">
         <input
           name="utilitiesIncluded"
           type="checkbox"
           defaultChecked={listing?.utilitiesIncluded ?? false}
-          className="h-4 w-4 rounded border-zinc-300"
+          className="h-4 w-4 rounded border-stone-300 text-brand-700 accent-brand-700"
         />
         Utilities included
       </label>
@@ -603,7 +605,7 @@ export function ListingCreateForm({
       ) : null}
 
       <div className="grid gap-2">
-        <label htmlFor="amenities" className="text-sm font-medium text-zinc-800">
+        <label htmlFor="amenities" className={fieldLabel()}>
           Amenities
         </label>
         <textarea
@@ -611,22 +613,22 @@ export function ListingCreateForm({
           name="amenities"
           rows={2}
           defaultValue={listing?.amenities.join(", ") ?? ""}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldTextarea()}
           placeholder="Laundry, parking, furnished"
         />
       </div>
 
       <div className="grid gap-3">
         <div className="flex items-center justify-between gap-3">
-          <p className="text-sm font-medium text-zinc-800">Images</p>
-          <p className="text-xs text-zinc-500">
+          <p className={fieldLabel()}>Images</p>
+          <p className="text-xs text-stone-500">
             {imageUrls.length}/{LISTING_IMAGE_MAX_COUNT}
           </p>
         </div>
         <div
           onDragOver={(event) => event.preventDefault()}
           onDrop={handleDrop}
-          className="grid gap-3 rounded-md border border-dashed border-zinc-300 px-4 py-6 text-center"
+          className="grid gap-3 rounded-2xl border border-dashed border-stone-300 bg-stone-50/60 px-4 py-8 text-center transition-colors hover:border-brand-300"
         >
           <input
             ref={fileInputRef}
@@ -641,11 +643,11 @@ export function ListingCreateForm({
               }
             }}
           />
-          <p className="text-sm text-zinc-600">Drop images here or choose files.</p>
+          <p className="text-sm text-stone-600">Drop images here or choose files.</p>
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            className="mx-auto rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-950 hover:bg-zinc-100"
+            className={buttonVariants({ variant: "secondary", size: "sm", className: "mx-auto" })}
           >
             Choose images
           </button>
@@ -655,7 +657,7 @@ export function ListingCreateForm({
             {imageUrls.map((imageUrl, index) => (
               <div
                 key={imageUrl}
-                className="relative h-28 w-36 shrink-0 overflow-hidden rounded-md border border-zinc-200 bg-zinc-100"
+                className="relative h-28 w-36 shrink-0 overflow-hidden rounded-xl border border-stone-200 bg-stone-100"
               >
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
@@ -670,7 +672,7 @@ export function ListingCreateForm({
                       current.filter((currentUrl) => currentUrl !== imageUrl),
                     )
                   }
-                  className="absolute right-2 top-2 rounded-md bg-white/90 px-2 py-1 text-xs font-medium text-zinc-950 shadow-sm hover:bg-white"
+                  className="absolute right-2 top-2 rounded-lg bg-white/90 px-2 py-1 text-xs font-medium text-stone-950 shadow-sm backdrop-blur hover:bg-white"
                 >
                   Remove
                 </button>
@@ -683,7 +685,7 @@ export function ListingCreateForm({
       <button
         type="submit"
         disabled={isSubmitting}
-        className="rounded-md bg-zinc-950 px-5 py-3 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+        className={buttonVariants({ size: "lg", className: "w-full sm:w-auto" })}
       >
         {isSubmitting
           ? isEditMode

--- a/apps/web/src/features/listings/components/listing-empty-state.tsx
+++ b/apps/web/src/features/listings/components/listing-empty-state.tsx
@@ -1,8 +1,29 @@
+import Link from "next/link";
+
+import { buttonVariants } from "@/features/ui/button";
+import { HomeMarkIcon } from "@/features/ui/icons";
+
 export function ListingEmptyState() {
   return (
-    <div className="rounded-md border border-dashed border-zinc-300 p-8 text-zinc-600">
-      No listings yet. Add seed data or create the first listing once posting is
-      enabled.
+    <div className="rounded-2xl border border-dashed border-stone-300 bg-surface px-6 py-16 text-center">
+      <span className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-brand-100 text-brand-700">
+        <HomeMarkIcon width={26} height={26} />
+      </span>
+      <h2 className="mt-5 text-lg font-semibold text-stone-950">
+        No listings match yet
+      </h2>
+      <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-stone-600">
+        Try widening your filters, or be the first to post an apartment, room,
+        or roommate lead near campus.
+      </p>
+      <div className="mt-6 flex flex-wrap justify-center gap-3">
+        <Link href="/listings" className={buttonVariants({ variant: "secondary" })}>
+          Clear filters
+        </Link>
+        <Link href="/listings/new" className={buttonVariants()}>
+          Post a listing
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/listings/components/listing-filter-form.tsx
+++ b/apps/web/src/features/listings/components/listing-filter-form.tsx
@@ -1,4 +1,5 @@
 import { type ListingQueryInput } from "@/features/listings/schemas";
+import { fieldInput, fieldLabel, fieldSelect } from "@/features/ui/field";
 
 export const LISTING_FILTER_FORM_ID = "listing-filter-form";
 
@@ -28,11 +29,11 @@ export function ListingFilterForm({ filters }: ListingFilterFormProps) {
       key={filterFormKey(filters)}
       id={LISTING_FILTER_FORM_ID}
       action="/listings"
-      className="mb-8 grid gap-4 rounded-md border border-zinc-200 p-4"
+      className="mb-8 grid gap-5 rounded-2xl border border-stone-200/80 bg-surface p-5 shadow-[var(--shadow-soft)] sm:p-6"
     >
       <div className="grid gap-4 md:grid-cols-3">
         <div className="grid gap-2">
-          <label htmlFor="rentMin" className="text-sm font-medium text-zinc-800">
+          <label htmlFor="rentMin" className={fieldLabel()}>
             Min price
           </label>
           <input
@@ -42,13 +43,13 @@ export function ListingFilterForm({ filters }: ListingFilterFormProps) {
             min="0"
             step="1"
             defaultValue={value(filters.rentMin)}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="700"
           />
         </div>
 
         <div className="grid gap-2">
-          <label htmlFor="rentMax" className="text-sm font-medium text-zinc-800">
+          <label htmlFor="rentMax" className={fieldLabel()}>
             Max price
           </label>
           <input
@@ -58,20 +59,20 @@ export function ListingFilterForm({ filters }: ListingFilterFormProps) {
             min="0"
             step="1"
             defaultValue={value(filters.rentMax)}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="1200"
           />
         </div>
 
         <div className="grid gap-2">
-          <label htmlFor="type" className="text-sm font-medium text-zinc-800">
+          <label htmlFor="type" className={fieldLabel()}>
             Home type
           </label>
           <select
             id="type"
             name="type"
             defaultValue={filters.type ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldSelect()}
           >
             <option value="">Any type</option>
             <option value="APARTMENT">Apartment</option>
@@ -83,10 +84,7 @@ export function ListingFilterForm({ filters }: ListingFilterFormProps) {
 
       <div className="grid gap-4 md:grid-cols-4">
         <div className="grid gap-2">
-          <label
-            htmlFor="bedroomsMin"
-            className="text-sm font-medium text-zinc-800"
-          >
+          <label htmlFor="bedroomsMin" className={fieldLabel()}>
             Beds
           </label>
           <input
@@ -96,16 +94,13 @@ export function ListingFilterForm({ filters }: ListingFilterFormProps) {
             min="0"
             step="1"
             defaultValue={value(filters.bedroomsMin)}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="1"
           />
         </div>
 
         <div className="grid gap-2">
-          <label
-            htmlFor="bathroomsMin"
-            className="text-sm font-medium text-zinc-800"
-          >
+          <label htmlFor="bathroomsMin" className={fieldLabel()}>
             Baths
           </label>
           <input
@@ -115,16 +110,13 @@ export function ListingFilterForm({ filters }: ListingFilterFormProps) {
             min="0"
             step="0.5"
             defaultValue={value(filters.bathroomsMin)}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="1"
           />
         </div>
 
         <div className="grid gap-2">
-          <label
-            htmlFor="availableBy"
-            className="text-sm font-medium text-zinc-800"
-          >
+          <label htmlFor="availableBy" className={fieldLabel()}>
             Move-in by
           </label>
           <input
@@ -132,22 +124,19 @@ export function ListingFilterForm({ filters }: ListingFilterFormProps) {
             name="availableBy"
             type="date"
             defaultValue={filters.availableBy ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
           />
         </div>
 
         <div className="grid gap-2">
-          <label
-            htmlFor="petPolicy"
-            className="text-sm font-medium text-zinc-800"
-          >
+          <label htmlFor="petPolicy" className={fieldLabel()}>
             Pet policy
           </label>
           <select
             id="petPolicy"
             name="petPolicy"
             defaultValue={filters.petPolicy ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldSelect()}
           >
             <option value="">Any policy</option>
             <option value="PETS_ALLOWED">Pets allowed</option>

--- a/apps/web/src/features/listings/components/listing-image-gallery.tsx
+++ b/apps/web/src/features/listings/components/listing-image-gallery.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 
+import { cn } from "@/features/ui/cn";
+
 type ListingImageGalleryProps = {
   imageUrls: string[];
 };
@@ -28,13 +30,13 @@ export function ListingImageGallery({ imageUrls }: ListingImageGalleryProps) {
   }
 
   return (
-    <section className="mt-8 grid gap-3" aria-label="Listing images">
-      <div className="relative overflow-hidden rounded-md border border-zinc-200 bg-zinc-100">
+    <section className="grid gap-3" aria-label="Listing images">
+      <div className="relative overflow-hidden rounded-2xl border border-stone-200/80 bg-stone-100 shadow-[var(--shadow-soft)]">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={activeImage}
           alt={`Listing image ${activeIndex + 1}`}
-          className="h-[min(58vw,520px)] min-h-72 w-full object-contain"
+          className="h-[min(58vw,520px)] min-h-72 w-full object-cover"
         />
         {images.length > 1 ? (
           <div className="absolute inset-x-3 top-1/2 flex -translate-y-1/2 justify-between">
@@ -42,18 +44,23 @@ export function ListingImageGallery({ imageUrls }: ListingImageGalleryProps) {
               type="button"
               onClick={showPrevious}
               aria-label="Previous image"
-              className="rounded-md bg-white/90 px-3 py-2 text-sm font-medium text-zinc-950 shadow-sm hover:bg-white"
+              className="flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg text-stone-900 shadow-md backdrop-blur transition hover:bg-white"
             >
-              Prev
+              ‹
             </button>
             <button
               type="button"
               onClick={showNext}
               aria-label="Next image"
-              className="rounded-md bg-white/90 px-3 py-2 text-sm font-medium text-zinc-950 shadow-sm hover:bg-white"
+              className="flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-lg text-stone-900 shadow-md backdrop-blur transition hover:bg-white"
             >
-              Next
+              ›
             </button>
+          </div>
+        ) : null}
+        {images.length > 1 ? (
+          <div className="absolute bottom-3 right-3 rounded-full bg-stone-950/70 px-2.5 py-1 text-xs font-medium text-white">
+            {activeIndex + 1} / {images.length}
           </div>
         ) : null}
       </div>
@@ -66,18 +73,15 @@ export function ListingImageGallery({ imageUrls }: ListingImageGalleryProps) {
               type="button"
               onClick={() => setActiveIndex(index)}
               aria-label={`Show image ${index + 1}`}
-              className={`h-20 w-28 shrink-0 overflow-hidden rounded-md border ${
+              className={cn(
+                "h-20 w-28 shrink-0 overflow-hidden rounded-xl border-2 transition",
                 activeIndex === index
-                  ? "border-zinc-950"
-                  : "border-zinc-200 hover:border-zinc-400"
-              }`}
+                  ? "border-brand-600"
+                  : "border-transparent opacity-70 hover:opacity-100",
+              )}
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={imageUrl}
-                alt=""
-                className="h-full w-full object-cover"
-              />
+              <img src={imageUrl} alt="" className="h-full w-full object-cover" />
             </button>
           ))}
         </div>

--- a/apps/web/src/features/profile/components/profile-account-form.tsx
+++ b/apps/web/src/features/profile/components/profile-account-form.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 
 import type { ProfileUser } from "@/features/profile/queries";
+import { buttonVariants } from "@/features/ui/button";
+import { fieldInput, fieldLabel } from "@/features/ui/field";
 import { FormFeedback } from "@/features/ui/form-feedback";
 
 type ApiErrorBody = {
@@ -68,7 +70,7 @@ export function ProfileAccountForm({ user }: { user: ProfileUser }) {
   return (
     <form
       onSubmit={handleSubmit}
-      className="mt-4 grid gap-4 rounded-md border border-zinc-200 p-4"
+      className="mt-4 grid gap-4 rounded-2xl border border-stone-200/80 bg-surface p-6 shadow-[var(--shadow-soft)]"
     >
       {error ? (
         <FormFeedback tone="error">{error}</FormFeedback>
@@ -84,7 +86,7 @@ export function ProfileAccountForm({ user }: { user: ProfileUser }) {
       <button
         type="submit"
         disabled={isSubmitting}
-        className="justify-self-start rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+        className={buttonVariants({ className: "justify-self-start" })}
       >
         {isSubmitting ? "Saving..." : "Save profile"}
       </button>
@@ -96,7 +98,7 @@ export function ProfileAccountFields({ user }: { user: ProfileUser }) {
   return (
     <>
       <div className="grid gap-2">
-        <label htmlFor="name" className="text-sm font-medium text-zinc-800">
+        <label htmlFor="name" className={fieldLabel()}>
           Display name
         </label>
         <input
@@ -104,7 +106,7 @@ export function ProfileAccountFields({ user }: { user: ProfileUser }) {
           name="name"
           required
           defaultValue={user.name ?? ""}
-          className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+          className={fieldInput()}
           placeholder="Kushal Singh"
         />
       </div>
@@ -113,7 +115,7 @@ export function ProfileAccountFields({ user }: { user: ProfileUser }) {
         <div className="grid gap-2">
           <label
             htmlFor="contactEmail"
-            className="text-sm font-medium text-zinc-800"
+            className={fieldLabel()}
           >
             Default contact email
           </label>
@@ -122,7 +124,7 @@ export function ProfileAccountFields({ user }: { user: ProfileUser }) {
             name="contactEmail"
             type="email"
             defaultValue={user.contactEmail ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder={user.email}
           />
         </div>
@@ -130,7 +132,7 @@ export function ProfileAccountFields({ user }: { user: ProfileUser }) {
         <div className="grid gap-2">
           <label
             htmlFor="contactPhone"
-            className="text-sm font-medium text-zinc-800"
+            className={fieldLabel()}
           >
             Default contact phone
           </label>
@@ -139,7 +141,7 @@ export function ProfileAccountFields({ user }: { user: ProfileUser }) {
             name="contactPhone"
             type="tel"
             defaultValue={user.contactPhone ?? ""}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950"
+            className={fieldInput()}
             placeholder="320-555-1212"
           />
         </div>

--- a/apps/web/src/features/reviews/components/review-section.tsx
+++ b/apps/web/src/features/reviews/components/review-section.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 import { useState, type Dispatch, type FormEvent, type SetStateAction } from "react";
 
 import type { ReviewApiResponse } from "@/features/reviews/schemas";
+import { buttonVariants } from "@/features/ui/button";
+import { fieldInput, fieldLabel } from "@/features/ui/field";
 import { FormFeedback } from "@/features/ui/form-feedback";
 
 type ReviewSectionProps = {
@@ -88,19 +90,19 @@ export function ReviewSectionView({
   const ratingCount = ratedReviewCount(reviews);
 
   return (
-    <section className="mt-10 border-t border-zinc-200 pt-8">
+    <section className="mt-10 border-t border-stone-200 pt-8">
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 className="text-2xl font-semibold text-zinc-950">
+          <h2 className="text-2xl font-semibold text-stone-950">
             Reviews and comments
           </h2>
-          <p className="mt-1 text-sm text-zinc-600">
+          <p className="mt-1 text-sm text-stone-600">
             {reviews.length === 0
               ? "No reviews yet."
               : `${reviews.length} review${reviews.length === 1 ? "" : "s"}`}
           </p>
           {averageRating ? (
-            <p className="mt-1 text-sm font-medium text-emerald-700">
+            <p className="mt-1 text-sm font-medium text-brand-700">
               {`${averageRating} average from ${ratingCount} rating${
                 ratingCount === 1 ? "" : "s"
               }`}
@@ -123,12 +125,12 @@ export function ReviewSectionView({
       ) : null}
 
       {isOwner ? (
-        <p className="mt-5 rounded-md border border-zinc-200 px-4 py-3 text-sm text-zinc-700">
+        <p className="mt-5 rounded-md border border-stone-200 px-4 py-3 text-sm text-stone-700">
           Owners cannot review their own listings.
         </p>
       ) : isSignedIn ? (
         <form onSubmit={onCreateReview} className="mt-5 grid gap-3">
-          <label htmlFor="review-body" className="text-sm font-medium text-zinc-800">
+          <label htmlFor="review-body" className={fieldLabel()}>
             Add a comment
           </label>
           <textarea
@@ -137,12 +139,12 @@ export function ReviewSectionView({
             required
             rows={4}
             disabled={isSubmitting}
-            className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950 disabled:bg-zinc-100"
+            className={fieldInput()}
             placeholder="Share what future renters should know."
           />
           <div className="flex flex-wrap items-end gap-3">
             <div className="grid gap-2">
-              <label htmlFor="review-rating" className="text-sm font-medium text-zinc-800">
+              <label htmlFor="review-rating" className={fieldLabel()}>
                 Rating
               </label>
               <select
@@ -150,7 +152,7 @@ export function ReviewSectionView({
                 name="rating"
                 defaultValue=""
                 disabled={isSubmitting}
-                className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950 disabled:bg-zinc-100"
+                className={fieldInput()}
               >
                 <option value="">No rating</option>
                 <option value="5">5</option>
@@ -163,14 +165,14 @@ export function ReviewSectionView({
             <button
               type="submit"
               disabled={isSubmitting}
-              className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+              className={buttonVariants({ size: "sm" })}
             >
               {isSubmitting ? "Posting..." : "Post review"}
             </button>
           </div>
         </form>
       ) : (
-        <p className="mt-5 rounded-md border border-zinc-200 px-4 py-3 text-sm text-zinc-700">
+        <p className="mt-5 rounded-md border border-stone-200 px-4 py-3 text-sm text-stone-700">
           Sign in to add a comment or rating.
         </p>
       )}
@@ -181,7 +183,7 @@ export function ReviewSectionView({
           const isEditing = editingReviewId === review.id;
 
           return (
-            <article key={review.id} className="border-t border-zinc-200 pt-5">
+            <article key={review.id} className="border-t border-stone-200 pt-5">
               {isEditing ? (
                 <form
                   onSubmit={(event) => onUpdateReview(event, review.id)}
@@ -193,14 +195,14 @@ export function ReviewSectionView({
                     rows={4}
                     defaultValue={review.body}
                     disabled={isSubmitting}
-                    className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950 disabled:bg-zinc-100"
+                    className={fieldInput()}
                   />
                   <div className="flex flex-wrap items-center gap-3">
                     <select
                       name="rating"
                       defaultValue={review.rating ?? ""}
                       disabled={isSubmitting}
-                      className="rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-950 disabled:bg-zinc-100"
+                      className={fieldInput()}
                     >
                       <option value="">No rating</option>
                       <option value="5">5</option>
@@ -212,7 +214,7 @@ export function ReviewSectionView({
                     <button
                       type="submit"
                       disabled={isSubmitting}
-                      className="rounded-md bg-zinc-950 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+                      className={buttonVariants({ size: "sm" })}
                     >
                       Save
                     </button>
@@ -220,7 +222,7 @@ export function ReviewSectionView({
                       type="button"
                       disabled={isSubmitting}
                       onClick={() => setEditingReviewId(null)}
-                      className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-800 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:bg-zinc-100 disabled:text-zinc-400"
+                      className={buttonVariants({ variant: "secondary", size: "sm" })}
                     >
                       Cancel
                     </button>
@@ -229,23 +231,23 @@ export function ReviewSectionView({
               ) : (
                 <div className="grid gap-2">
                   <div className="flex flex-wrap items-center justify-between gap-3">
-                    <p className="text-sm font-medium text-zinc-950">
+                    <p className="text-sm font-medium text-stone-950">
                       {reviewAuthor(review)}
                     </p>
                     {review.rating ? (
-                      <p className="text-sm font-semibold text-emerald-700">
+                      <p className="text-sm font-semibold text-brand-700">
                         {reviewRatingLabel(review.rating)}
                       </p>
                     ) : null}
                   </div>
-                  <p className="leading-7 text-zinc-700">{review.body}</p>
+                  <p className="leading-7 text-stone-700">{review.body}</p>
                   {isAuthor ? (
                     <div className="flex flex-wrap gap-3">
                       <button
                         type="button"
                         onClick={() => onEditReview(review.id)}
                         disabled={isSubmitting}
-                        className="text-sm font-medium text-zinc-950 underline-offset-4 hover:underline disabled:text-zinc-400"
+                        className="text-sm font-medium text-stone-950 underline-offset-4 hover:underline disabled:text-stone-400"
                       >
                         Edit
                       </button>

--- a/apps/web/src/features/saved-listings/components/saved-listing-button.tsx
+++ b/apps/web/src/features/saved-listings/components/saved-listing-button.tsx
@@ -3,6 +3,8 @@
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
+import { cn } from "@/features/ui/cn";
+import { HeartIcon } from "@/features/ui/icons";
 import { FormFeedback } from "@/features/ui/form-feedback";
 
 type SavedListingButtonProps = {
@@ -57,12 +59,18 @@ export function SavedListingButton({
         onClick={handleClick}
         disabled={isUpdating || isPending}
         aria-pressed={isSaved}
-        className={
+        className={cn(
+          "inline-flex items-center gap-2 rounded-xl px-3.5 py-2 text-sm font-medium transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-60",
           isSaved
-            ? "rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-950 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-70"
-            : "rounded-md border border-zinc-300 px-3 py-2 text-sm font-medium text-zinc-950 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-70"
-        }
+            ? "bg-brand-100 text-brand-900 hover:bg-brand-200"
+            : "border border-stone-300 bg-surface text-stone-900 hover:border-stone-400 hover:bg-stone-50",
+        )}
       >
+        <HeartIcon
+          width={16}
+          height={16}
+          className={isSaved ? "fill-brand-700" : undefined}
+        />
         {isSaved ? "Saved" : "Save"}
       </button>
       {error ? <FormFeedback tone="error">{error}</FormFeedback> : null}

--- a/apps/web/src/features/ui/badge.tsx
+++ b/apps/web/src/features/ui/badge.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+
+import { cn, type ClassValue } from "@/features/ui/cn";
+
+export type BadgeTone =
+  | "brand"
+  | "neutral"
+  | "success"
+  | "muted"
+  | "outline";
+
+const tones: Record<BadgeTone, string> = {
+  brand: "bg-brand-100 text-brand-900",
+  neutral: "bg-stone-900 text-stone-50",
+  success: "bg-emerald-100 text-emerald-900",
+  muted: "bg-stone-100 text-stone-600",
+  outline: "border border-stone-300 text-stone-700",
+};
+
+type BadgeProps = {
+  children: ReactNode;
+  tone?: BadgeTone;
+  className?: ClassValue;
+};
+
+/** Small status / category pill. */
+export function Badge({ children, tone = "brand", className }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold uppercase tracking-wide",
+        tones[tone],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+const LISTING_TYPE_LABELS: Record<string, string> = {
+  APARTMENT: "Apartment",
+  ROOM: "Room",
+  ROOMMATE: "Roommate",
+};
+
+export function listingTypeLabel(type: string): string {
+  return LISTING_TYPE_LABELS[type] ?? type;
+}
+
+const LISTING_STATUS_TONE: Record<string, BadgeTone> = {
+  ACTIVE: "success",
+  DRAFT: "muted",
+  RENTED: "neutral",
+  ARCHIVED: "muted",
+};
+
+export function listingStatusTone(status: string): BadgeTone {
+  return LISTING_STATUS_TONE[status] ?? "muted";
+}

--- a/apps/web/src/features/ui/button.ts
+++ b/apps/web/src/features/ui/button.ts
@@ -1,0 +1,51 @@
+import { cn, type ClassValue } from "@/features/ui/cn";
+
+export type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "ghost"
+  | "danger"
+  | "subtle";
+export type ButtonSize = "sm" | "md" | "lg";
+
+const base =
+  "inline-flex items-center justify-center gap-2 rounded-xl font-medium " +
+  "transition-all duration-150 ease-out focus-visible:outline-none " +
+  "disabled:cursor-not-allowed disabled:opacity-60 active:translate-y-px " +
+  "whitespace-nowrap";
+
+const variants: Record<ButtonVariant, string> = {
+  primary:
+    "bg-brand-800 text-brand-50 shadow-[var(--shadow-soft)] hover:bg-brand-900",
+  secondary:
+    "border border-stone-300 bg-surface text-stone-900 hover:border-stone-400 hover:bg-stone-50",
+  subtle:
+    "bg-brand-100 text-brand-900 hover:bg-brand-200",
+  ghost: "text-stone-700 hover:bg-stone-100 hover:text-stone-950",
+  danger:
+    "border border-red-200 bg-surface text-red-700 hover:border-red-300 hover:bg-red-50",
+};
+
+const sizes: Record<ButtonSize, string> = {
+  sm: "px-3 py-1.5 text-sm",
+  md: "px-4 py-2.5 text-sm",
+  lg: "px-6 py-3 text-base",
+};
+
+type ButtonVariantOptions = {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: ClassValue;
+};
+
+/**
+ * Shared button styling used by both <button> elements and <Link>
+ * call-to-actions so primary/secondary/ghost treatments stay consistent.
+ */
+export function buttonVariants({
+  variant = "primary",
+  size = "md",
+  className,
+}: ButtonVariantOptions = {}): string {
+  return cn(base, variants[variant], sizes[size], className);
+}

--- a/apps/web/src/features/ui/card.tsx
+++ b/apps/web/src/features/ui/card.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+
+import { cn, type ClassValue } from "@/features/ui/cn";
+
+type CardProps = {
+  children: ReactNode;
+  className?: ClassValue;
+  as?: "div" | "article" | "section" | "form";
+  interactive?: boolean;
+};
+
+/** Surface container with the warm-wood border + soft shadow treatment. */
+export function Card({
+  children,
+  className,
+  as: Tag = "div",
+  interactive = false,
+}: CardProps) {
+  return (
+    <Tag
+      className={cn(
+        "rounded-2xl border border-stone-200/80 bg-surface shadow-[var(--shadow-soft)]",
+        interactive &&
+          "transition-all duration-200 hover:-translate-y-0.5 hover:border-brand-200 hover:shadow-[var(--shadow-lift)]",
+        className,
+      )}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+/** Section eyebrow label — small uppercase brand text above a heading. */
+export function Eyebrow({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: ClassValue;
+}) {
+  return (
+    <p
+      className={cn(
+        "text-xs font-semibold uppercase tracking-[0.18em] text-brand-700",
+        className,
+      )}
+    >
+      {children}
+    </p>
+  );
+}

--- a/apps/web/src/features/ui/cn.ts
+++ b/apps/web/src/features/ui/cn.ts
@@ -1,0 +1,10 @@
+/**
+ * Minimal className combiner. Joins truthy class fragments with a space.
+ * Avoids pulling in a dependency for the small amount of conditional
+ * styling the UI layer needs.
+ */
+export type ClassValue = string | number | false | null | undefined;
+
+export function cn(...values: ClassValue[]): string {
+  return values.filter(Boolean).join(" ");
+}

--- a/apps/web/src/features/ui/container.tsx
+++ b/apps/web/src/features/ui/container.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+import { cn, type ClassValue } from "@/features/ui/cn";
+
+type ContainerProps = {
+  children: ReactNode;
+  className?: ClassValue;
+  size?: "sm" | "md" | "lg";
+};
+
+const sizes = {
+  sm: "max-w-3xl",
+  md: "max-w-5xl",
+  lg: "max-w-6xl",
+};
+
+/** Centered page gutter with consistent horizontal padding. */
+export function Container({ children, className, size = "lg" }: ContainerProps) {
+  return (
+    <div className={cn("mx-auto w-full px-5 sm:px-8", sizes[size], className)}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/features/ui/field.ts
+++ b/apps/web/src/features/ui/field.ts
@@ -1,0 +1,35 @@
+import { cn, type ClassValue } from "@/features/ui/cn";
+
+/**
+ * Shared form-control styling. Forms keep their existing DOM/labels/names
+ * (covered by tests) and just adopt these class strings for a consistent,
+ * warm look with on-brand focus states.
+ */
+const controlBase =
+  "w-full rounded-xl border border-stone-300 bg-surface px-3.5 py-2.5 text-sm " +
+  "text-stone-900 shadow-sm outline-none transition-colors " +
+  "placeholder:text-stone-400 " +
+  "focus:border-brand-500 focus:ring-2 focus:ring-brand-500/25 " +
+  "disabled:cursor-not-allowed disabled:bg-stone-100 disabled:text-stone-500";
+
+export function fieldInput(className?: ClassValue): string {
+  return cn(controlBase, className);
+}
+
+/* Custom chevron so `appearance-none` selects keep a clear dropdown affordance. */
+const selectChevron =
+  "appearance-none bg-no-repeat pr-10 " +
+  "[background-image:url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2216%22 height=%2216%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%2378716c%22 stroke-width=%222%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22><path d=%22m6 9 6 6 6-6%22/></svg>')] " +
+  "[background-position:right_0.75rem_center] [background-size:1rem]";
+
+export function fieldSelect(className?: ClassValue): string {
+  return cn(controlBase, selectChevron, className);
+}
+
+export function fieldTextarea(className?: ClassValue): string {
+  return cn(controlBase, "resize-y leading-6", className);
+}
+
+export function fieldLabel(className?: ClassValue): string {
+  return cn("text-sm font-medium text-stone-800", className);
+}

--- a/apps/web/src/features/ui/form-feedback.tsx
+++ b/apps/web/src/features/ui/form-feedback.tsx
@@ -7,7 +7,7 @@ type FormFeedbackProps = {
 
 const toneClassNames = {
   error: "border-red-200 bg-red-50 text-red-700",
-  info: "border-sky-200 bg-sky-50 text-sky-800",
+  info: "border-brand-200 bg-brand-50 text-brand-800",
   success: "border-emerald-200 bg-emerald-50 text-emerald-800",
 };
 
@@ -18,7 +18,7 @@ export function FormFeedback({ tone, children }: FormFeedbackProps) {
     <div
       role={isError ? "alert" : "status"}
       aria-live={isError ? "assertive" : "polite"}
-      className={`rounded-md border px-4 py-3 text-sm ${toneClassNames[tone]}`}
+      className={`flex items-start gap-2 rounded-xl border px-4 py-3 text-sm ${toneClassNames[tone]}`}
     >
       {children}
     </div>

--- a/apps/web/src/features/ui/icons.tsx
+++ b/apps/web/src/features/ui/icons.tsx
@@ -1,0 +1,123 @@
+import type { SVGProps } from "react";
+
+/**
+ * Small inline icon set (stroke-based, currentColor). Inline SVG keeps the
+ * bundle dependency-free and lets icons inherit text color + size.
+ */
+type IconProps = SVGProps<SVGSVGElement>;
+
+function Icon({ children, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      width={20}
+      height={20}
+      {...props}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function HomeMarkIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M3 10.5 12 3l9 7.5" />
+      <path d="M5 9.5V20a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9.5" />
+      <path d="M9.5 21v-6h5v6" />
+    </Icon>
+  );
+}
+
+export function BedIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M3 8v11" />
+      <path d="M3 18h18v-3a3 3 0 0 0-3-3H3" />
+      <path d="M7 12V9a1 1 0 0 1 1-1h6" />
+      <path d="M21 18v2" />
+    </Icon>
+  );
+}
+
+export function BathIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M4 12V6a2 2 0 0 1 4 0v.5" />
+      <path d="M3 12h18v2a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z" />
+      <path d="M6 18l-1 2M18 18l1 2" />
+    </Icon>
+  );
+}
+
+export function PinIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M12 21s-6-5.2-6-10a6 6 0 1 1 12 0c0 4.8-6 10-6 10Z" />
+      <circle cx="12" cy="11" r="2.2" />
+    </Icon>
+  );
+}
+
+export function StarIcon(props: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      width={16}
+      height={16}
+      {...props}
+    >
+      <path d="m12 2.5 2.9 5.9 6.5.9-4.7 4.6 1.1 6.5L12 18l-5.8 3 1.1-6.5L2.6 9.9l6.5-.9z" />
+    </svg>
+  );
+}
+
+export function HeartIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M12 20s-7-4.3-9.3-9C1.4 8.4 2.7 5.5 5.6 5a4.3 4.3 0 0 1 4.1 1.7l.3.4.3-.4A4.3 4.3 0 0 1 14.4 5c2.9.5 4.2 3.4 2.9 6-2.3 4.7-9.3 9-9.3 9Z" />
+    </Icon>
+  );
+}
+
+export function CheckIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="m20 6-11 11-5-5" />
+    </Icon>
+  );
+}
+
+export function ArrowRightIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M5 12h14" />
+      <path d="m13 6 6 6-6 6" />
+    </Icon>
+  );
+}
+
+export function MailIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <path d="m3.5 7 8.5 6 8.5-6" />
+    </Icon>
+  );
+}
+
+export function PhoneIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M6.5 3h3l1.5 4-2 1.5a12 12 0 0 0 5 5l1.5-2 4 1.5v3a2 2 0 0 1-2.2 2A16.5 16.5 0 0 1 4.5 5.2 2 2 0 0 1 6.5 3Z" />
+    </Icon>
+  );
+}


### PR DESCRIPTION
## Summary

Implemented the existing API to build a front end

## Design system (new)

- `app/globals.css` — brand/surface/ink color tokens, serif display, warm brown-tinted shadows, hero grain wash
- `features/ui/` — `cn`, `buttonVariants` (primary/secondary/ghost/danger/subtle), `Badge`, `Card`/`Eyebrow`, `Container`, shared field styles (input/select/textarea/label), and a dependency-free inline icon set
- `app/nav-link.tsx` — client `NavLink` with an active-route treatment

No new dependencies, and no network-loaded fonts (system stack + Georgia) so the build stays reliable.

## Reskinned surfaces

- **Chrome:** sticky blurred nav with logo mark + active states, new footer
- **Home:** editorial hero, value-prop cards, how-it-works, closing CTA
- **Listings:** image-forward cards (type badge, price emphasis, beds/baths/distance meta), restyled filter card, friendlier empty state
- **Listing detail:** two-column layout with a sticky price + save/contact sidebar, upgraded image gallery
- **Forms:** create/edit, contact-request, and review sections moved onto shared field styles and buttons
- **Auth & profile:** centered auth cards; profile dashboard with status pills and card rows

## Verification

- `npm run build` ✓ (TypeScript clean)
- `npm run lint` ✓
- `npm test` → 146/146 ✓