### PR TITLE
Rebrand to RentNest, genericize copy, and gate API docs behind auth

### DIFF
--- a/apps/web/src/app/api-docs/page.tsx
+++ b/apps/web/src/app/api-docs/page.tsx
@@ -1,15 +1,31 @@
-import { SwaggerDocs } from "@/app/api-docs/swagger-docs";
+import { redirect } from "next/navigation";
 
-export default function ApiDocsPage() {
+import { SwaggerDocs } from "@/app/api-docs/swagger-docs";
+import { Eyebrow } from "@/features/ui/card";
+import { auth } from "@/server/auth/auth";
+
+export const dynamic = "force-dynamic";
+
+export default async function ApiDocsPage() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/login?callbackUrl=%2Fapi-docs");
+  }
+
   return (
-    <main className="min-h-screen bg-white">
-      <div className="border-b border-zinc-200 px-6 py-5">
-        <p className="text-sm font-semibold uppercase tracking-normal text-emerald-700">
-          AllApartments API
-        </p>
-        <h1 className="mt-2 text-3xl font-semibold text-zinc-950">
-          API documentation
-        </h1>
+    <main className="min-h-screen bg-surface">
+      <div className="border-b border-stone-200/70 bg-background px-6 py-6">
+        <div className="mx-auto max-w-6xl">
+          <Eyebrow>RentNest API</Eyebrow>
+          <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight text-stone-950">
+            API documentation
+          </h1>
+          <p className="mt-2 text-sm text-stone-600">
+            Signed in as {session.user.email ?? session.user.name}. These docs
+            are visible to authenticated users only.
+          </p>
+        </div>
       </div>
       <SwaggerDocs />
     </main>

--- a/apps/web/src/app/api/openapi.json/route.ts
+++ b/apps/web/src/app/api/openapi.json/route.ts
@@ -1,7 +1,19 @@
 import { createOpenApiDocument } from "@/server/api/openapi";
+import { auth } from "@/server/auth/auth";
 
-export const dynamic = "force-static";
+// Dynamic so the session cookie can be checked per request — the spec is
+// only exposed to authenticated users (the docs UI fetches it with creds).
+export const dynamic = "force-dynamic";
 
 export async function GET() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return Response.json(
+      { error: { code: "UNAUTHORIZED", message: "Authentication required." } },
+      { status: 401 },
+    );
+  }
+
   return Response.json(createOpenApiDocument());
 }

--- a/apps/web/src/app/app-footer.tsx
+++ b/apps/web/src/app/app-footer.tsx
@@ -21,7 +21,7 @@ export function AppFooter() {
                 <HomeMarkIcon width={18} height={18} />
               </span>
               <span className="font-display text-base font-semibold text-stone-950">
-                AllApartments
+                RentNest
               </span>
             </div>
             <p className="mt-3 text-sm leading-6 text-stone-600">
@@ -43,7 +43,7 @@ export function AppFooter() {
           </nav>
         </div>
         <div className="border-t border-stone-200/70 py-6 text-xs text-stone-500">
-          © {new Date().getFullYear()} AllApartments. Find apartments, rooms,
+          © {new Date().getFullYear()} RentNest. Find apartments, rooms,
           and roommates.
         </div>
       </Container>

--- a/apps/web/src/app/app-nav.tsx
+++ b/apps/web/src/app/app-nav.tsx
@@ -16,13 +16,13 @@ export async function AppNav() {
           <Link
             href="/"
             className="group flex items-center gap-2.5"
-            aria-label="AllApartments home"
+            aria-label="RentNest home"
           >
             <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-800 text-brand-50 shadow-[var(--shadow-soft)] transition-transform group-hover:-rotate-3">
               <HomeMarkIcon width={20} height={20} />
             </span>
             <span className="font-display text-lg font-semibold text-stone-950">
-              AllApartments
+              RentNest
             </span>
           </Link>
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2,7 +2,7 @@
 @import "swagger-ui-react/swagger-ui.css";
 
 /*
-  AllApartments design system — "warm wood"
+  RentNest design system — "warm wood"
   A cozy, editorial housing marketplace palette: cream paper, walnut/oak
   brand tones, and warm stone neutrals. Serif display + humanist sans body.
 */

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,11 +5,11 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: {
-    default: "AllApartments — apartments, rooms & roommates",
-    template: "%s · AllApartments",
+    default: "RentNest — apartments, rooms & roommates",
+    template: "%s · RentNest",
   },
   description:
-    "Find apartments, rooms, and roommate leads near campus. A warm, local-first rental board.",
+    "Find apartments, rooms, and roommates anywhere. A warm, simple rental board for renters and posters alike.",
 };
 
 export default function RootLayout({

--- a/apps/web/src/app/listings/new/page.tsx
+++ b/apps/web/src/app/listings/new/page.tsx
@@ -18,7 +18,7 @@ export default async function NewListingPage() {
     <main className="mx-auto w-full max-w-3xl px-5 py-10 sm:px-8 sm:py-12">
       <Eyebrow>Post listing</Eyebrow>
       <h1 className="mt-3 font-display text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl">
-        Share an apartment or room near campus.
+        Share an apartment, room, or roommate lead.
       </h1>
       <p className="mt-4 leading-8 text-stone-600">
         Add the essentials first. You can edit details after the post is live.

--- a/apps/web/src/app/listings/page.tsx
+++ b/apps/web/src/app/listings/page.tsx
@@ -59,7 +59,7 @@ export default async function ListingsPage({ searchParams }: ListingsPageProps) 
           <div>
             <Eyebrow>Browse</Eyebrow>
             <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl">
-              Listings near campus
+Browse listings
             </h1>
             <p className="mt-2 text-stone-600">{resultLabel}</p>
           </div>

--- a/apps/web/src/app/login/page.test.tsx
+++ b/apps/web/src/app/login/page.test.tsx
@@ -49,7 +49,7 @@ describe("LoginPage", () => {
       searchParams: Promise.resolve({ callbackUrl: "/profile" }),
     });
 
-    expect(includesText(page, "Sign in to AllApartments")).toBe(true);
+    expect(includesText(page, "Sign in to RentNest")).toBe(true);
     const form = (page.props.children as unknown[]).at(-1) as {
       props: { callbackUrl?: string };
     };

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -23,7 +23,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
     <main className="mx-auto my-16 w-[calc(100%-2.5rem)] max-w-md rounded-2xl border border-stone-200/80 bg-surface p-8 shadow-[var(--shadow-soft)] sm:my-24 sm:p-10">
       <Eyebrow>Welcome back</Eyebrow>
       <h1 className="mt-3 font-display text-3xl font-semibold tracking-tight text-stone-950">
-        Sign in to AllApartments
+        Sign in to RentNest
       </h1>
       <p className="mt-3 leading-7 text-stone-600">
         Use your email and password to post and manage housing leads.

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -33,7 +33,7 @@ const STEPS = [
   {
     step: "01",
     title: "Browse the board",
-    body: "Search active listings near campus and open the ones that catch your eye.",
+    body: "Search active listings in your area and open the ones that catch your eye.",
   },
   {
     step: "02",
@@ -64,9 +64,9 @@ export default function Home() {
                 <span className="text-brand-700"> feels like home.</span>
               </h1>
               <p className="max-w-xl text-lg leading-8 text-stone-600">
-                Browse trusted apartments, rooms, and roommate leads near
-                campus. Compare rent, save your favorites, and reach posters
-                without the noise.
+                Browse trusted apartments, rooms, and roommates wherever
+                you&apos;re headed. Compare rent, save your favorites, and reach
+                posters without the noise.
               </p>
               <div className="flex flex-wrap gap-3">
                 <Link href="/listings" className={buttonVariants({ size: "lg" })}>
@@ -84,7 +84,7 @@ export default function Home() {
                 {[
                   ["3 in 1", "Apartments · rooms · roommates"],
                   ["Free", "To browse and to post"],
-                  ["Local", "Built around campus life"],
+                  ["Anywhere", "Built for renters everywhere"],
                 ].map(([stat, label]) => (
                   <div key={label}>
                     <dt className="font-display text-2xl font-semibold text-stone-950">
@@ -108,12 +108,12 @@ export default function Home() {
                 <div className="space-y-3 p-6">
                   <div className="flex items-baseline justify-between">
                     <p className="font-display text-lg font-semibold text-stone-950">
-                      Sunny 2BR near campus
+                      Sunny 2BR downtown
                     </p>
                     <p className="font-semibold text-brand-800">$1,150</p>
                   </div>
                   <p className="text-sm text-stone-500">
-                    2 bed · 1 bath · 0.4 mi to campus
+                    2 bed · 1 bath · 0.4 mi to transit
                   </p>
                   <div className="flex gap-2 pt-1">
                     {["Laundry", "Parking", "Furnished"].map((tag) => (
@@ -136,7 +136,7 @@ export default function Home() {
       <section className="py-16 sm:py-20">
         <Container>
           <div className="max-w-2xl">
-            <Eyebrow>Why AllApartments</Eyebrow>
+            <Eyebrow>Why RentNest</Eyebrow>
             <h2 className="mt-3 font-display text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl">
               Housing search, minus the headache.
             </h2>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -160,7 +160,7 @@ export default async function ProfilePage() {
             </h3>
             <p className="mx-auto mt-2 max-w-md text-sm text-stone-600">
               Post your first apartment, room, or roommate lead so renters can
-              find it near campus.
+              find it.
             </p>
             <Link
               href="/listings/new"

--- a/apps/web/src/app/register/page.test.tsx
+++ b/apps/web/src/app/register/page.test.tsx
@@ -49,7 +49,7 @@ describe("RegisterPage", () => {
       searchParams: Promise.resolve({ callbackUrl: "/profile" }),
     });
 
-    expect(includesText(page, "Join AllApartments")).toBe(true);
+    expect(includesText(page, "Join RentNest")).toBe(true);
     const form = (page.props.children as unknown[]).at(-1) as {
       props: { callbackUrl?: string };
     };

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -23,7 +23,7 @@ export default async function RegisterPage({ searchParams }: RegisterPageProps) 
     <main className="mx-auto my-16 w-[calc(100%-2.5rem)] max-w-md rounded-2xl border border-stone-200/80 bg-surface p-8 shadow-[var(--shadow-soft)] sm:my-24 sm:p-10">
       <Eyebrow>Create account</Eyebrow>
       <h1 className="mt-3 font-display text-3xl font-semibold tracking-tight text-stone-950">
-        Join AllApartments
+        Join RentNest
       </h1>
       <p className="mt-3 leading-7 text-stone-600">
         Create a local account to post listings and keep ownership tied to you.

--- a/apps/web/src/features/listings/components/listing-create-form.tsx
+++ b/apps/web/src/features/listings/components/listing-create-form.tsx
@@ -365,7 +365,7 @@ export function ListingCreateForm({
           required
           defaultValue={listing?.title}
           className={fieldInput()}
-          placeholder="Sunny room near campus"
+          placeholder="Sunny room downtown"
         />
       </div>
 
@@ -479,7 +479,7 @@ export function ListingCreateForm({
             htmlFor="distanceToCampus"
             className={fieldLabel()}
           >
-            Distance to campus
+            Distance to transit
           </label>
           <input
             id="distanceToCampus"

--- a/apps/web/src/features/listings/components/listing-empty-state.tsx
+++ b/apps/web/src/features/listings/components/listing-empty-state.tsx
@@ -14,7 +14,7 @@ export function ListingEmptyState() {
       </h2>
       <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-stone-600">
         Try widening your filters, or be the first to post an apartment, room,
-        or roommate lead near campus.
+        or roommate lead in your area.
       </p>
       <div className="mt-6 flex flex-wrap justify-center gap-3">
         <Link href="/listings" className={buttonVariants({ variant: "secondary" })}>

--- a/apps/web/src/features/reviews/components/review-section.tsx
+++ b/apps/web/src/features/reviews/components/review-section.tsx
@@ -27,7 +27,7 @@ async function readErrorMessage(response: Response, fallback: string) {
 }
 
 function reviewAuthor(review: ReviewApiResponse) {
-  return review.authorName ?? "AllApartments user";
+  return review.authorName ?? "RentNest user";
 }
 
 export function averageReviewRating(reviews: ReviewApiResponse[]) {

--- a/apps/web/src/server/api/openapi.ts
+++ b/apps/web/src/server/api/openapi.ts
@@ -348,7 +348,7 @@ export function createOpenApiDocument() {
   return generator.generateDocument({
     openapi: "3.0.0",
     info: {
-      title: "AllApartments API",
+      title: "RentNest API",
       version: "0.1.0",
       description: "Schema-driven API documentation for the StCloudAptss migration.",
     },


### PR DESCRIPTION
## Summary

Two refinements on top of the warm-wood redesign:

1. **Rebrand "AllApartments" → "RentNest"** and remove the campus-specific framing so the product reads as a generic, nationwide rental board for **apartments, rooms, and roommates** (not just student housing).
2. **Gate `/api-docs` behind authentication** — it was previously readable by anyone.



## API docs auth

The docs decision was to **reuse the existing NextAuth session** rather than introduce new tokens (bearer API keys would be the right call for programmatic/third-party access, but that's a separate, larger feature; HTTP Basic was rejected — reusable creds per request, base64 ≠ encryption, no clean revocation).

- `/api-docs` redirects signed-out users to `/login?callbackUrl=/api-docs` and shows the signed-in identity.
- `/api/openapi.json` now returns **401** unless authenticated, so the raw spec isn't public either. Swagger UI fetches it same-origin, so the session cookie rides along for logged-in users. (The route flips from static to dynamic as a result.)

## Verification

- `npm run build` ✓ (TypeScript clean)
- `npm run lint` ✓
- `npm test` → 146/146 ✓