### PR TITLE
Polish responsive listing UI

### DIFF
--- a/apps/web/src/app/app-nav.test.tsx
+++ b/apps/web/src/app/app-nav.test.tsx
@@ -30,6 +30,34 @@ function hasHref(node: unknown, href: string): boolean {
   return hasHref(children, href);
 }
 
+function hasClassFragment(node: unknown, fragment: string): boolean {
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const element = node as {
+    props?: {
+      children?: unknown;
+      className?: unknown;
+    };
+  };
+
+  if (
+    typeof element.props?.className === "string" &&
+    element.props.className.includes(fragment)
+  ) {
+    return true;
+  }
+
+  const children = element.props?.children;
+
+  if (Array.isArray(children)) {
+    return children.some((child) => hasClassFragment(child, fragment));
+  }
+
+  return hasClassFragment(children, fragment);
+}
+
 describe("AppNav", () => {
   it("shows a profile link for signed-in users", async () => {
     vi.mocked(auth).mockResolvedValue({
@@ -50,5 +78,15 @@ describe("AppNav", () => {
     const nav = await AppNav();
 
     expect(hasHref(nav, "/profile")).toBe(false);
+  });
+
+  it("keeps the signed-out nav from overflowing narrow screens", async () => {
+    vi.mocked(auth).mockResolvedValue(null);
+
+    const nav = await AppNav();
+
+    expect(hasClassFragment(nav, "min-w-0")).toBe(true);
+    expect(hasClassFragment(nav, "max-[360px]:hidden")).toBe(true);
+    expect(hasClassFragment(nav, "max-[360px]:px-2.5")).toBe(true);
   });
 });

--- a/apps/web/src/app/app-nav.tsx
+++ b/apps/web/src/app/app-nav.tsx
@@ -11,22 +11,22 @@ export async function AppNav() {
 
   return (
     <header className="sticky top-0 z-40 border-b border-stone-200/70 bg-background/85 backdrop-blur-md">
-      <Container>
-        <div className="flex h-16 items-center justify-between gap-4">
+      <Container className="px-3 sm:px-8">
+        <div className="flex h-16 min-w-0 items-center justify-between gap-2 sm:gap-4">
           <Link
             href="/"
-            className="group flex items-center gap-2.5"
+            className="group flex min-w-0 items-center gap-2.5"
             aria-label="RentNest home"
           >
-            <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-800 text-brand-50 shadow-[var(--shadow-soft)] transition-transform group-hover:-rotate-3">
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-brand-800 text-brand-50 shadow-[var(--shadow-soft)] transition-transform group-hover:-rotate-3">
               <HomeMarkIcon width={20} height={20} />
             </span>
-            <span className="font-display text-lg font-semibold text-stone-950">
+            <span className="truncate font-display text-lg font-semibold text-stone-950 max-[360px]:hidden">
               RentNest
             </span>
           </Link>
 
-          <nav className="flex items-center gap-1 sm:gap-2">
+          <nav className="flex shrink-0 items-center gap-0.5 sm:gap-2">
             <NavLink href="/listings">Listings</NavLink>
             <NavLink href="/listings/new">Post</NavLink>
             {session?.user ? (
@@ -53,7 +53,10 @@ export async function AppNav() {
             ) : (
               <Link
                 href="/login"
-                className={buttonVariants({ size: "sm", className: "ml-1" })}
+                className={buttonVariants({
+                  size: "sm",
+                  className: "ml-0.5 max-[360px]:px-2.5 sm:ml-1",
+                })}
               >
                 Sign in
               </Link>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -26,6 +26,13 @@
   --color-brand-900: #58321f;
   --color-brand-950: #32190e;
 
+  /* Secondary trust accent used sparingly for hierarchy and empty states */
+  --color-accent-50: #edf8f4;
+  --color-accent-100: #d5efe6;
+  --color-accent-200: #abdccc;
+  --color-accent-700: #24705e;
+  --color-accent-800: #1f5d50;
+
   /* Type */
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
     Helvetica, Arial, sans-serif;

--- a/apps/web/src/app/nav-link.tsx
+++ b/apps/web/src/app/nav-link.tsx
@@ -24,7 +24,7 @@ export function NavLink({ href, children }: NavLinkProps) {
       href={href}
       aria-current={isActive ? "page" : undefined}
       className={cn(
-        "relative rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+        "relative rounded-lg px-2 py-2 text-sm font-medium transition-colors sm:px-3",
         isActive
           ? "text-brand-900"
           : "text-stone-600 hover:text-stone-950",

--- a/apps/web/src/features/listings/components/listing-card.test.tsx
+++ b/apps/web/src/features/listings/components/listing-card.test.tsx
@@ -60,4 +60,10 @@ describe("ListingCard", () => {
 
     expect(includesText(card, "Quiet weekdays")).toBe(true);
   });
+
+  it("uses a housing-specific empty image state when no photo exists", () => {
+    const card = ListingCard({ listing });
+
+    expect(includesText(card, "No photo yet")).toBe(true);
+  });
 });

--- a/apps/web/src/features/listings/components/listing-card.tsx
+++ b/apps/web/src/features/listings/components/listing-card.tsx
@@ -52,8 +52,13 @@ export function ListingCard({
               className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
             />
           ) : (
-            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-brand-200 via-brand-300 to-brand-500 text-brand-900/70">
-              <PinIcon width={32} height={32} />
+            <div className="flex h-full w-full flex-col items-center justify-center gap-2 bg-[linear-gradient(135deg,var(--color-brand-100),var(--color-accent-100))] text-brand-900/75">
+              <span className="flex h-12 w-12 items-center justify-center rounded-full bg-surface/80 shadow-[var(--shadow-soft)]">
+                <PinIcon width={24} height={24} />
+              </span>
+              <span className="text-xs font-semibold uppercase tracking-[0.14em]">
+                No photo yet
+              </span>
             </div>
           )}
           <div className="absolute left-3 top-3">

--- a/apps/web/src/features/listings/components/listing-filter-form.test.tsx
+++ b/apps/web/src/features/listings/components/listing-filter-form.test.tsx
@@ -34,6 +34,53 @@ function formKey(node: unknown) {
     : null;
 }
 
+function includesText(node: unknown, text: string): boolean {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node).includes(text);
+  }
+
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const element = node as { props?: { children?: unknown } };
+  const children = element.props?.children;
+
+  if (Array.isArray(children)) {
+    return children.some((child) => includesText(child, text));
+  }
+
+  return includesText(children, text);
+}
+
+function hasClassFragment(node: unknown, fragment: string): boolean {
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const element = node as {
+    props?: {
+      children?: unknown;
+      className?: unknown;
+    };
+  };
+
+  if (
+    typeof element.props?.className === "string" &&
+    element.props.className.includes(fragment)
+  ) {
+    return true;
+  }
+
+  const children = element.props?.children;
+
+  if (Array.isArray(children)) {
+    return children.some((child) => hasClassFragment(child, fragment));
+  }
+
+  return hasClassFragment(children, fragment);
+}
+
 describe("ListingFilterForm", () => {
   it("renders current listing discovery filters", () => {
     const form = ListingFilterForm({
@@ -68,5 +115,15 @@ describe("ListingFilterForm", () => {
 
     expect(formKey(selectedForm)).toBe("||ROOM||||PETS_ALLOWED");
     expect(formKey(clearedForm)).toBe("||||||");
+  });
+
+  it("collapses the filter controls behind a mobile summary", () => {
+    const form = ListingFilterForm({
+      filters: {},
+    });
+
+    expect(includesText(form, "Filters")).toBe(true);
+    expect(hasClassFragment(form, "peer-checked:grid")).toBe(true);
+    expect(hasClassFragment(form, "md:grid")).toBe(true);
   });
 });

--- a/apps/web/src/features/listings/components/listing-filter-form.tsx
+++ b/apps/web/src/features/listings/components/listing-filter-form.tsx
@@ -23,130 +23,154 @@ function filterFormKey(filters: ListingQueryInput) {
   ].join("|");
 }
 
+function hasActiveFilters(filters: ListingQueryInput) {
+  return Object.values(filters).some((filterValue) => filterValue !== undefined);
+}
+
 export function ListingFilterForm({ filters }: ListingFilterFormProps) {
   return (
-    <form
+    <div
       key={filterFormKey(filters)}
-      id={LISTING_FILTER_FORM_ID}
-      action="/listings"
-      className="mb-8 grid gap-5 rounded-2xl border border-stone-200/80 bg-surface p-5 shadow-[var(--shadow-soft)] sm:p-6"
+      className="mb-8 rounded-2xl border border-stone-200/80 bg-surface shadow-[var(--shadow-soft)]"
     >
-      <div className="grid gap-4 md:grid-cols-3">
-        <div className="grid gap-2">
-          <label htmlFor="rentMin" className={fieldLabel()}>
-            Min price
-          </label>
-          <input
-            id="rentMin"
-            name="rentMin"
-            type="number"
-            min="0"
-            step="1"
-            defaultValue={value(filters.rentMin)}
-            className={fieldInput()}
-            placeholder="700"
-          />
+      <input
+        id="listing-filter-toggle"
+        type="checkbox"
+        className="peer sr-only"
+        defaultChecked={hasActiveFilters(filters)}
+        aria-label="Show listing filters"
+      />
+      <label
+        htmlFor="listing-filter-toggle"
+        className="flex cursor-pointer items-center justify-between gap-4 p-5 text-sm font-semibold text-stone-950 md:hidden"
+      >
+        <span>Filters</span>
+        <span className="text-xs font-medium uppercase tracking-[0.14em] text-brand-700">
+          Rent · type · move-in
+        </span>
+      </label>
+      <form
+        id={LISTING_FILTER_FORM_ID}
+        action="/listings"
+        className="hidden gap-5 border-t border-stone-100 p-5 peer-checked:grid md:grid md:border-t-0 sm:p-6"
+      >
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="grid gap-2">
+            <label htmlFor="rentMin" className={fieldLabel()}>
+              Min price
+            </label>
+            <input
+              id="rentMin"
+              name="rentMin"
+              type="number"
+              min="0"
+              step="1"
+              defaultValue={value(filters.rentMin)}
+              className={fieldInput()}
+              placeholder="700"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <label htmlFor="rentMax" className={fieldLabel()}>
+              Max price
+            </label>
+            <input
+              id="rentMax"
+              name="rentMax"
+              type="number"
+              min="0"
+              step="1"
+              defaultValue={value(filters.rentMax)}
+              className={fieldInput()}
+              placeholder="1200"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <label htmlFor="type" className={fieldLabel()}>
+              Home type
+            </label>
+            <select
+              id="type"
+              name="type"
+              defaultValue={filters.type ?? ""}
+              className={fieldSelect()}
+            >
+              <option value="">Any type</option>
+              <option value="APARTMENT">Apartment</option>
+              <option value="ROOM">Room</option>
+              <option value="ROOMMATE">Roommate lead</option>
+            </select>
+          </div>
         </div>
 
-        <div className="grid gap-2">
-          <label htmlFor="rentMax" className={fieldLabel()}>
-            Max price
-          </label>
-          <input
-            id="rentMax"
-            name="rentMax"
-            type="number"
-            min="0"
-            step="1"
-            defaultValue={value(filters.rentMax)}
-            className={fieldInput()}
-            placeholder="1200"
-          />
-        </div>
+        <div className="grid gap-4 md:grid-cols-4">
+          <div className="grid gap-2">
+            <label htmlFor="bedroomsMin" className={fieldLabel()}>
+              Beds
+            </label>
+            <input
+              id="bedroomsMin"
+              name="bedroomsMin"
+              type="number"
+              min="0"
+              step="1"
+              defaultValue={value(filters.bedroomsMin)}
+              className={fieldInput()}
+              placeholder="1"
+            />
+          </div>
 
-        <div className="grid gap-2">
-          <label htmlFor="type" className={fieldLabel()}>
-            Home type
-          </label>
-          <select
-            id="type"
-            name="type"
-            defaultValue={filters.type ?? ""}
-            className={fieldSelect()}
-          >
-            <option value="">Any type</option>
-            <option value="APARTMENT">Apartment</option>
-            <option value="ROOM">Room</option>
-            <option value="ROOMMATE">Roommate lead</option>
-          </select>
-        </div>
-      </div>
+          <div className="grid gap-2">
+            <label htmlFor="bathroomsMin" className={fieldLabel()}>
+              Baths
+            </label>
+            <input
+              id="bathroomsMin"
+              name="bathroomsMin"
+              type="number"
+              min="0"
+              step="0.5"
+              defaultValue={value(filters.bathroomsMin)}
+              className={fieldInput()}
+              placeholder="1"
+            />
+          </div>
 
-      <div className="grid gap-4 md:grid-cols-4">
-        <div className="grid gap-2">
-          <label htmlFor="bedroomsMin" className={fieldLabel()}>
-            Beds
-          </label>
-          <input
-            id="bedroomsMin"
-            name="bedroomsMin"
-            type="number"
-            min="0"
-            step="1"
-            defaultValue={value(filters.bedroomsMin)}
-            className={fieldInput()}
-            placeholder="1"
-          />
-        </div>
+          <div className="grid gap-2">
+            <label htmlFor="availableBy" className={fieldLabel()}>
+              Move-in by
+            </label>
+            <input
+              id="availableBy"
+              name="availableBy"
+              type="date"
+              defaultValue={filters.availableBy ?? ""}
+              className={fieldInput()}
+            />
+          </div>
 
-        <div className="grid gap-2">
-          <label htmlFor="bathroomsMin" className={fieldLabel()}>
-            Baths
-          </label>
-          <input
-            id="bathroomsMin"
-            name="bathroomsMin"
-            type="number"
-            min="0"
-            step="0.5"
-            defaultValue={value(filters.bathroomsMin)}
-            className={fieldInput()}
-            placeholder="1"
-          />
+          <div className="grid gap-2">
+            <label htmlFor="petPolicy" className={fieldLabel()}>
+              Pet policy
+            </label>
+            <select
+              id="petPolicy"
+              name="petPolicy"
+              defaultValue={filters.petPolicy ?? ""}
+              className={fieldSelect()}
+            >
+              <option value="">Any policy</option>
+              <option value="PETS_ALLOWED">Pets allowed</option>
+              <option value="CATS_ONLY">Cats only</option>
+              <option value="DOGS_ONLY">Dogs only</option>
+              <option value="NO_PETS">No pets</option>
+              <option value="UNKNOWN">Not specified</option>
+            </select>
+          </div>
         </div>
-
-        <div className="grid gap-2">
-          <label htmlFor="availableBy" className={fieldLabel()}>
-            Move-in by
-          </label>
-          <input
-            id="availableBy"
-            name="availableBy"
-            type="date"
-            defaultValue={filters.availableBy ?? ""}
-            className={fieldInput()}
-          />
-        </div>
-
-        <div className="grid gap-2">
-          <label htmlFor="petPolicy" className={fieldLabel()}>
-            Pet policy
-          </label>
-          <select
-            id="petPolicy"
-            name="petPolicy"
-            defaultValue={filters.petPolicy ?? ""}
-            className={fieldSelect()}
-          >
-            <option value="">Any policy</option>
-            <option value="PETS_ALLOWED">Pets allowed</option>
-            <option value="CATS_ONLY">Cats only</option>
-            <option value="DOGS_ONLY">Dogs only</option>
-            <option value="NO_PETS">No pets</option>
-            <option value="UNKNOWN">Not specified</option>
-          </select>
-        </div>
-      </div>
-    </form>
+      </form>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fix narrow mobile nav overflow by tightening spacing and hiding the wordmark at very small widths.
- Collapse listing filters behind a mobile filter toggle while keeping the full filter form visible on desktop.
- Improve no-photo listing cards with a clearer housing-specific placeholder and add a small secondary accent palette.
- Add regression coverage for responsive nav, mobile filter behavior, and empty listing imagery.

## Validation
- `npm run test`
- `npm run build`
- `npm run lint`
- Browser checked desktop and 320px mobile layouts for `/` and `/listings`.