### PR TITLE
Run prisma generate during build for Vercel deploys

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",


### PR DESCRIPTION
## What changed

The `build` script in `apps/web/package.json` now runs `prisma generate` before `next build`.
